### PR TITLE
1.3.3 — what a player and an operator actually hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,99 @@
 
 Notable changes to OpenMW-Web. Dates are release dates, newest first.
 
+## 1.3.3
+
+Found by running it, not by reading it. 1.3.2 fixed what the two programs disagreed about;
+1.3.3 is what a player and an operator actually hit when you walk the product end to end.
+
+**A friend handed the server address could not get in.** The Multiplayer card offered three
+greyed-out "Soon" buttons and told them to ask the operator to enable a sign-in method. The
+operator had already enabled one: `/auth/providers` has always reported `allowPasswordLogin`
+beside the provider list, and the launcher read only the list. Password sign-in now renders
+there and hands off through the same path the SSO redirect takes, so character select and world
+dial-in stay one path rather than two that drift.
+
+**The page described a different server from the one the operator set up.** Under "your game
+data" it told players they would upload their own Data Files to a personal locker — on a server
+whose operator had just chosen "served by this server" and installed Morrowind once for
+everyone. It asks the server now: the manifest route answers 404 unless this server serves the
+game, so its status is the answer.
+
+**Adding a friend handed them the dashboard.** There is no self-serve sign-up on a password
+server, so "add someone" is where a friend's account comes from — and its access list held only
+viewer, moderator and owner. Every player an operator added got a login to the admin dashboard.
+"Player" is now offered, and is the default.
+
+**Settings the operator can answer, and none they cannot.** Free text became dropdowns wherever
+the parser already has an enum, fed by one map so the two cannot drift. Fields the wizard
+derives are refused at the endpoint rather than merely hidden. Respawn stopped asking for four
+coordinates nobody knows — the operator points at a standing player instead, which is by
+construction a place a person can stand and works for vanilla, mods and Tamriel Rebuilt alike.
+
+**State nobody owned.** A client could invent unlimited weather regions, each one a row written
+to disk and replayed at every future joiner. Chat had no rate limit despite the protocol
+promising one, so a client sitting just under the message budget reached every player on the
+world indefinitely. The clock's day rollover gave up past ~18,000 hours and left the hour out of
+range on disk, reachable from a plugin or from a tick after the host machine slept — time the
+server was not running is not time that passed in the world. The who-is-playing map was swept
+for tokens but never for its own entries.
+
+**The two halves of the server disagreed about how long a month is.** One collapsed the calendar
+assuming twelve 28-day months while the clock rolled the real Morrowind lengths, so the count
+ran backwards leaving a 31-day month — and a merchant drained near a boundary stayed drained for
+up to three game days.
+
+**An optional browser binding could stop a player reporting movement.** The page bridge is
+Emscripten-only and was called on the first line of `onFrame`, so on any engine without it the
+throw took movement, equipment and barter reporting down with it for the whole session.
+
+**The player cap is the operator's number again.** 1.3.2 clamped it to a hidden 32 while
+`/status` still advertised what was configured; the clamp is gone and capacity is enforced once,
+against the same field that is advertised. And since 1.2.0 the locker origin was never offered
+at all — right when the wizard captured a domain and derived it, wrong on the one path that
+captures none, where the base falls back to loopback and the server's own warning named a field
+the dashboard refused to accept.
+
+Fourteen server-to-client events existed only in the source, so a coverage audit built from the
+protocol document skipped every one of them. They are documented, and the ones that had no test
+have one. The boot-performance gate stopped gating on a ratio that moved 10% with machine load
+and in the wrong direction for its own purpose.
+
+1050 server tests, 64 browser scenarios green on real clients.
+
+## 1.3.2
+
+Thirteen defects, most of them one shape: something wired into one of the two programs and not
+the other, or a rule enforced in the view and not at the door.
+
+**What an operator hits.** The multiplayer server never served the game files they uploaded, so
+players were asked to supply a game the operator had already provided. Switching to the image
+with the engine — which `docker-compose.yml` tells you to do — made every existing file
+unreadable, because the two images ran as different uids; the entrypoint repairs ownership and
+drops privileges now. The multiplayer server never regenerated its proxy config at boot, so a
+restored backup or a changed answer never took effect. Password-reset mail pointed at loopback
+on any server with a domain. The deployment shape (mode, hosting, domain, port, content profile)
+was editable from the settings page, which changed the record and did none of the work the
+wizard does — `setup.completed` was one PUT from reopening first-run setup on a live server.
+
+**What a player hits.** A friend request to someone in their own game was stored and never
+delivered; the row that did arrive named them by their account key, which for an SSO account is
+a real name; and it could not be accepted, because the accept resolved names against the local
+roster. An invite across worlds was never delivered either, and an invite from a friend vanished
+from the panel within ten seconds because every snapshot deleted it. A full world told the
+owner's friend it was private, at a seat count nobody advertised.
+
+**What an operator never sees until it matters.** A world that wedged while occupied was never
+reaped, holding its port, its slot and its memory until the gateway restarted. The log wrote
+credentials to all three sinks, and measured its own file with a syscall on every line. A
+signed-in player could hold unlimited upload authorisations.
+
+Eight new browser scenarios cover paths that had none: server-hosted game files, blocking,
+cross-world invites, the operator's platform actions, closing your world on guests, reports,
+ban/unban, and maintenance. Two of that release's bugs were found by them.
+
+1033 server tests, 54 browser scenarios, mode flip proven on both images.
+
 ## 1.3.1
 
 One way in, for operators and for players. 1.3.0 made the world shareable; 1.3.1 settles who

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -706,6 +706,15 @@ end
 -- is run under pcall and answered with an 'ack' event carrying its id -- a throwing handler
 -- reports itself instead of silently killing every command after it in the same frame.
 local function pollCommands()
+    -- THE PAGE BRIDGE IS OPTIONAL, AND THIS RUNS FIRST. mp.pollCommands is a browser binding;
+    -- a headless engine has no page, and an engine built before the bridge existed has no
+    -- binding at all. Unguarded, that threw on the very first frame -- and because this call
+    -- is the first line of onFrame, it took walkTick, testEquipTick, barterMirrorTick AND
+    -- movementTick down with it for the entire session, at 20 errors a second. A sim peer in
+    -- that state answers the wire but never reports itself, so it never takes a cell and
+    -- nothing drives the NPCs, which reads as "authority is broken" and is nothing of the
+    -- kind. An optional convenience must not be able to stop a player reporting movement.
+    if type(mp.pollCommands) ~= 'function' then return end
     local raw = mp.pollCommands()
     if type(raw) ~= 'string' or raw == '' then return end
     local okDecode, list = pcall(json.decode, raw)

--- a/play/launcher.html
+++ b/play/launcher.html
@@ -302,6 +302,8 @@
  .mp-prov:hover{background:#fff} .mp-prov:active{transform:translateY(1px)}
  .mp-prov:focus-visible{outline:2px solid var(--gold); outline-offset:2px}
  .mp-prov svg{width:19px; height:19px; flex:none}
+ .mp-pw{margin-top:6px}
+ .mp-pw #mp-pw-go{margin-top:18px}
  .mp-fine{font-size:11.5px; color:var(--faint); line-height:1.55; margin:16px 0 0}
 
  /* Action cue - the whole tile is clickable, so this is a text prompt, not a button. */
@@ -635,20 +637,19 @@
      <p>Same account, same library. If you uploaded there, this just works, and the other way
         round.</p>`,
    mp: `
-     <div class="m-kicker">Play together &middot; single sign-on</div>
+     <!-- No "single sign-on" here: how you sign in depends on how THIS server was set up, and
+          describeThisServer() says so a few lines down once it has asked. -->
+     <div class="m-kicker">Play together</div>
      <h3 id="modal-title">Multiplayer</h3>
      <p>One account, one character, three ways to play: <b>solo</b> in your own private world,
         in a <b>party</b> with friends, or in the shared <b>public</b> world. Your character and
         progress follow you between all three, on any device.</p>
      <h4>Signing in</h4>
-     <p>Multiplayer uses <b>single sign-on</b> (e.g. Continue with Google), so there's no password
-        to create or manage. Signing in is what lets your character and saves persist and sync.</p>
+     <p id="mp-help-signin">Signing in is what lets your character and saves persist and sync.</p>
      <h4>Your game data</h4>
-     <p>The first time, you upload your own <b>Data Files</b> once to your private, account-only
-        locker; after that they stream back to you on any device. They stay private to you and are
-        never shared. You confirm they're your own backup copies of a game you legally own.</p>
+     <p id="mp-help-data">Checking how this server supplies the game…</p>
      <div class="m-hr"></div>
-     <p style="margin-top:16px">Just press <b>Sign in</b> and choose a provider.</p>`,
+     <p style="margin-top:16px" id="mp-help-go">Press <b>Sign in</b> to get started.</p>`,
    sample: `
      <div class="m-kicker">Free sample &middot; no download of the game</div>
      <h3 id="modal-title">The example world</h3>
@@ -772,7 +773,49 @@
  };
  (function(){
    const bd=$('modal-bd'), body=$('modal-body');
-   function open(key){ body.innerHTML = HELP[key]; bd.classList.add('show'); $('modal-close').focus(); }
+   function open(key){
+     body.innerHTML = HELP[key];
+     bd.classList.add('show'); $('modal-close').focus();
+     if (key === 'mp') describeThisServer();
+   }
+
+   // THIS SERVER, NOT THE HOSTED ONE. Every word under "Signing in" and "Your game data" used
+   // to be written for the hosted platform: single sign-on, and a per-player locker you upload
+   // your own Data Files to. On a self-hosted server that had already been set up for
+   // username-and-password with the game served from disk, both paragraphs were simply untrue --
+   // and the second one told a player to go and upload a copy of Morrowind that the operator
+   // had already installed for everyone. Ask the server instead; it answers both questions.
+   async function describeThisServer(){
+     let providers = [], password = false, serves = false;
+     try {
+       const doc = await (await fetch('/auth/providers')).json();
+       providers = doc.providers || [];
+       password = doc.allowPasswordLogin === true;
+     } catch(e){ /* leave the neutral wording in place */ }
+     // The manifest route 404s unless this server is set to serve the game itself, so its
+     // status IS the answer -- no second endpoint to keep in step with the first.
+     try { serves = (await fetch('/mwdata-manifest.json', { method:'HEAD' })).ok; } catch(e){}
+     const signin = $('mp-help-signin'), data = $('mp-help-data'), go = $('mp-help-go');
+     if (signin) {
+       signin.innerHTML = (password && providers.length ? 'Sign in with a <b>username and password</b>, or with an account you already have elsewhere. '
+         : password ? 'Sign in with the <b>username and password</b> the operator gave you. '
+         : providers.length ? 'Sign in with an account you already have (<b>single sign-on</b>), so there is no password to create or manage. '
+         : 'Sign-in is not set up on this server yet — ask the operator to turn on a way to sign in. ')
+         + 'Signing in is what lets your character and saves persist and sync.';
+     }
+     if (data) {
+       data.innerHTML = serves
+         ? 'Nothing to upload. <b>This server supplies the game</b> to everyone who plays on it, '
+           + 'so it streams to you when you join.'
+         : 'The first time, you upload your own <b>Data Files</b> once to your private, account-only '
+           + 'locker; after that they stream back to you on any device. They stay private to you and '
+           + 'are never shared. You confirm they’re your own backup copies of a game you legally own.';
+     }
+     if (go) {
+       go.innerHTML = 'Just press <b>Sign in</b>'
+         + (password && !providers.length ? '.' : ' and choose how you want to sign in.');
+     }
+   }
    function close(){ bd.classList.remove('show'); }
    // The "?" buttons live inside clickable cards — stop the event so the card's start/pick handler
    // doesn't also fire (on both click and keyboard activation).
@@ -1068,10 +1111,19 @@
    const http = httpBaseOf(url);
    if (!http){ mpNote('The multiplayer server is misconfigured. Contact the operator.','err'); return; }
    mpNote('Connecting…','muted');
-   let list;
+   let list, allowPassword;
    try {
      const r = await fetch(http + '/auth/providers', { mode:'cors' });
-     list = ((await r.json()) || {}).providers || [];
+     const doc = (await r.json()) || {};
+     list = doc.providers || [];
+     // THE SERVER SAYS SO IN THE SAME BREATH. This endpoint has always returned
+     // allowPasswordLogin next to the provider list, and only the provider list was ever read
+     // -- so a server set up for username-and-password (which the wizard offers first, and
+     // which /auth/password serves perfectly well) showed three greyed-out "Soon" buttons and
+     // told the player to go and ask the operator to enable something. The operator had
+     // already enabled it. This was the multiplayer door being shut on a correctly configured
+     // server, and the only way in was the other login page, which nothing links to from here.
+     allowPassword = doc.allowPasswordLogin === true;
    } catch(e){
      mpNote('Could not reach the multiplayer server. It may be down, try again shortly.','err');
      return;
@@ -1097,8 +1149,49 @@
      }
      box.appendChild(b);
    });
-   if (!firstLive) mpNote('No sign-in provider is enabled yet. Ask the operator to turn one on.','err');
-   else firstLive.focus();
+   if (allowPassword) mpPasswordForm(box, http);
+   if (!firstLive && !allowPassword) {
+     mpNote('No sign-in provider is enabled yet. Ask the operator to turn one on.','err');
+   } else if (firstLive) firstLive.focus();
+ }
+
+ // Username-and-password sign-in, rendered under the provider line-up when the server accepts
+ // it. /auth/password answers with exactly what an SSO round trip comes back with -- a boot
+ // ticket, the account key and a locker token -- so this hands off through the SAME fragment
+ // the redirect would have returned, and handleSsoReturn does the rest. One entry path for
+ // both doors: a second copy of character select and world dial-in is how they drift apart.
+ function mpPasswordForm(box, http){
+   const wrap = document.createElement('form');
+   wrap.className = 'mp-pw';
+   wrap.innerHTML =
+     '<label class="ob-field"><span>Username</span><input id="mp-pw-name" autocomplete="username" required></label>'
+   + '<label class="ob-field"><span>Password</span><input id="mp-pw-pass" type="password" autocomplete="current-password" required></label>'
+   + '<button class="mp-prov" id="mp-pw-go" type="submit"><span>Sign in</span></button>';
+   box.appendChild(wrap);
+   wrap.addEventListener('submit', async function(e){
+     e.preventDefault();
+     const go = $('mp-pw-go');
+     go.disabled = true;
+     mpNote('Signing in…','muted');
+     let doc;
+     try {
+       const r = await fetch(http + '/auth/password', {
+         method:'POST', mode:'cors', headers:{ 'content-type':'application/json' },
+         body: JSON.stringify({ name: $('mp-pw-name').value.trim(), password: $('mp-pw-pass').value }),
+       });
+       doc = await r.json();
+       if (!r.ok) { mpNote((doc && doc.error) || 'Could not sign in.','err'); go.disabled = false; return; }
+     } catch(err){
+       mpNote('Could not reach the multiplayer server. It may be down, try again shortly.','err');
+       go.disabled = false; return;
+     }
+     // Same as mpGoProvider: remember which tile asked, because the reload below loses it.
+     try { sessionStorage.setItem('omw-signin-intent', window.__omwSignInIntent || 'mp'); } catch(err){}
+     location.hash = '#mpticket=' + encodeURIComponent(doc.ticket)
+       + '&mpaccount=' + encodeURIComponent(doc.account)
+       + (doc.locker ? '&mplocker=' + encodeURIComponent(doc.locker) : '');
+     location.reload();
+   });
  }
 
  // First-login onboarding modal: collect a unique public username (and email if we have none),

--- a/server/PROTOCOL.md
+++ b/server/PROTOCOL.md
@@ -674,6 +674,29 @@ Storage is `node:sqlite` in the existing data dir. This is only correct because 
 is single-process; if the map is ever region-sharded across processes, the social data has
 to move out to a shared service first.
 
+## Server-to-client replies and pushes
+
+These are sent by the server and were, until now, documented only in the source. They are
+listed here so the wire surface has one complete index: a coverage audit built from this file
+silently skipped every one of them.
+
+| name | dir | body |
+|---|---|---|
+| `CombatRefused` | S→C | `{reason=string}` — an M5 attack the server would not apply (rate, shape, PvP veto). Told rather than dropped, so a swing that does nothing is explainable |
+| `WorldTimeRefused` | S→C | `{reason=string}` — the `[rules] timeSkip` refusal. A Rest that silently does nothing gets pressed again and reported as a bug |
+| `ObjectSpawnRefused` | S→C | `{tempId=number, ok=bool, reason=string}` — M3 drop conservation and placement refusals |
+| `ObjectTakeResult` | S→C | `{opId=number, ok=bool, reason=string?}` — the paired answer to `ObjectTakeRequest`; always sent, so a client never waits |
+| `CellSnapshotReplace` | S→C | `{cellKey=string, placed={…}, deleted={…}}` — the restored cell truth pushed straight after a `WorldCellReset`, so a reset is transparent rather than a kick |
+| `QuestSpawn` | S→C on cell entry | `{recordId=string, questId=string, cellKey=string}` — the operator's quest-repair rules replacing an object the character still needs |
+| `WorldList` | S→C, answering the C→S `WorldList` | `{error=string, myPort=number, worlds={{id, mode, name, host, port, wsPath?, playerCount, maxPlayers, up}, …}}` — mapped field by field: the gateway's record carries `ownerAccount` and it must never reach a client |
+| `WorldCreate` | S→C, answering the C→S `WorldCreate` | `{ok=bool, error=string, world={id, mode, name, host, port, wsPath?}?}` |
+| `WorldMode` | S→C at join and on change | `{mode=string}` — this world's mode, for the where-am-I switcher |
+| `WorldClosed` | S→C | `{reason=string, by=string}` — the owner took the world solo; guests are told before they are disconnected |
+| `SimReady` | S→C | `{ready=bool}` — whether a world peer is simulating yet |
+| `SimAnchors` | S→PEER | `{anchors={…}, interiors={…}, place?}` — the cells the peer is to simulate |
+| `AvatarRestore` | S→PEER | `{id=int, hp?, mp?, ft?}` — restore an avatar's bars from the stored doc |
+| `AvatarResurrect` | S→PEER | `{id=int, …}` — the peer-side half of a respawn |
+
 ## Client-side integration contract (M0)
 
 - Join URL: `index.html?...&mp=<ws(s)-url>&name=<display-name>`; boot JS sets

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmw-mp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "description": "Relay/validator/persister server for openmw-web multiplayer (omw-mp/1, M0)",

--- a/server/src/auth/identities.ts
+++ b/server/src/auth/identities.ts
@@ -390,6 +390,16 @@ export class LockerSessionStore {
   private sweep(): void {
     const now = Date.now();
     for (const [t, e] of [...this.tokens]) if (e.expiresAt <= now) this.tokens.delete(t);
+    // lastSeen was swept by nothing. activeSince() filters by its cutoff when it READS, so the
+    // answers were always right and the map behind them only ever grew: one entry for every
+    // account that has ever made an authenticated locker or save request, held for the life of
+    // the process. Small each, unbounded in total, and on a platform that is every account
+    // that ever plays.
+    //
+    // Anything older than a token's lifetime cannot be part of any answer — activeSince is
+    // asked about minutes, never days — so it is dropped on the same pass that expires tokens.
+    const stale = now - this.ttlMs;
+    for (const [account, at] of [...this.lastSeen]) if (at <= stale) this.lastSeen.delete(account);
   }
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -128,6 +128,9 @@ export interface Config {
   // maxSaveBytesPerAccount caps server-side savegames, which are a separate budget from the
   // game-data library — a full library must not make the player unable to save.
   locker: {
+    /** Whether players may store anything on this server at all. See the parse for why this
+     *  is a real switch rather than "did you configure storage". */
+    enabled: boolean;
     endpoint: string; region: string; bucket: string; maxBytesPerAccount: number;
     acceptByNameAndSize: boolean; publicBase: string; maxSaveBytesPerAccount: number;
     accessKeyId: string; secretAccessKey: string;
@@ -552,6 +555,12 @@ function validate(t: Tree): Config {
       refuseUnownedDrops: optBool(t, 'economy', 'refuseUnownedDrops', false),
     },
     locker: {
+      // ON UNLESS SOMEBODY SAYS OTHERWISE. There was no off switch: "enabled" meant "storage
+      // is configured", and storage is ALWAYS configured because an absent S3 endpoint falls
+      // back to this server's own disk. So an operator who did not want to host anyone's files
+      // had no way to say so, and the settings page showed them a storage section with no
+      // indication of whether it was doing anything.
+      enabled: optBool(t, 'locker', 'enabled', true),
       endpoint: reqStr(t, 'locker', 'endpoint'),
       region: reqStr(t, 'locker', 'region'),
       bucket: reqStr(t, 'locker', 'bucket'),

--- a/server/src/core/weather.ts
+++ b/server/src/core/weather.ts
@@ -24,6 +24,14 @@ import { log } from '../log';
 
 const MAX_REGION = 64;
 const MAX_WEATHER_ID = 255;
+// Regions cannot be validated: cell->region lives in the content files and this server never
+// reads them, so a client is free to declare regions that do not exist -- the same hole the
+// per-session cell bound closes in net/connection.ts. It is WORSE here. A cell key costs a
+// session an authority entry; a region costs the WORLD a row in global.json that is written
+// to disk and replayed to every future joiner, one WorldWeather event each. So the bound is
+// global rather than per-session. Vanilla plus both expansions is a dozen or so regions and
+// the largest landmass mods add tens: 256 is far above honest play and far below harm.
+const MAX_REGIONS = 256;
 
 export interface WeatherCtx {
   roster: Roster;
@@ -44,8 +52,13 @@ export class WeatherRegions {
   private queue: Promise<void> = Promise.resolve();
   // playerId -> region they last declared (needed to leave on change/disconnect).
   private playerRegion = new Map<number, string>();
+  // Every region this world has ever admitted, seeded from what is already persisted so a
+  // restart cannot be used to reset the bound.
+  private readonly known: Set<string>;
+  private floodLogged = false;
 
   constructor(private readonly ctx: WeatherCtx) {
+    this.known = new Set(Object.keys(ctx.weather));
     this.authority = new Authority({
       grant: (playerId, key, _epoch, snapshot) => {
         this.send(playerId, 'WorldWeatherAuthority', { region: key, holderId: playerId });
@@ -117,6 +130,21 @@ export class WeatherRegions {
     const playerId = player.id;
     const from = this.playerRegion.get(playerId);
     if (from === to) return;
+    if (!this.known.has(to)) {
+      if (this.known.size >= MAX_REGIONS) {
+        // Refuse the move outright rather than leaving the region on entry: the player stays
+        // where they were and keeps whatever authority they held, which is a consistent state.
+        if (!this.floodLogged) {
+          this.floodLogged = true;
+          log('warn', 'weather.region_flood', {
+            from: player.name, region: to, cap: MAX_REGIONS,
+            note: 'refusing new regions for this world; weather elsewhere is unaffected',
+          });
+        }
+        return;
+      }
+      this.known.add(to);
+    }
     this.playerRegion.set(playerId, to);
     this.enqueue(async () => {
       if (from) await this.authority.onLeave(playerId, from, true);

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -11,6 +11,7 @@ import { lToJs, type LTable, type LValue, type JsLike } from '../proto/lser';
 import { parseObjRef, objRefToJs, netRefKey, type ObjRef } from '../proto/ref';
 import type { Player, Roster } from './players';
 import { cellsVisible, lodStride, parseExterior, MAX_ABS_COORD, type InterestSettings, loadedCells, isChargenCell } from './movement';
+import { MONTH_DAYS } from './worldtime';
 import { unpackActorMoveBatch } from '../proto/movement';
 import { MSG_ACTOR_MOVE_BATCH, packEnvelope, nextBroadcastSeq } from '../proto/envelope';
 import { Authority, type ActorSnapshot } from './authority';
@@ -31,10 +32,19 @@ const MAX_GOLD_DELTA = 1000000;
 // rather than inventing a richer rule.
 const GOLD_RESTOCK_HOURS = 24;
 
-// Morrowind's calendar: 12 months of 28 days, no leap years. Collapsed to one number so two
-// readings can be compared; only DIFFERENCES matter, so the epoch is arbitrary.
+// Morrowind's calendar collapsed to one number so two readings can be compared; only
+// DIFFERENCES matter, so the epoch is arbitrary.
+//
+// MONTHS ARE NOT ALL 28 DAYS. This used to assume they were, while the clock that produces
+// these values rolls the real MW lengths (31/28/31/30/...). The two disagreed, so crossing
+// out of a 31-day month made the "absolute" hour count go BACKWARDS by up to three days --
+// and a merchant whose restock fell due around a month boundary was simply not restocked
+// until the calendar caught up again. MONTH_DAYS is imported rather than restated for that
+// reason: one copy of the calendar, or it drifts again.
 function absGameHours(t: { gameHour: number; day: number; month: number; year: number }): number {
-  return (((t.year * 12 + (t.month - 1)) * 28) + (t.day - 1)) * 24 + t.gameHour;
+  let days = t.year * 365 + (t.day - 1); // sum(MONTH_DAYS) === 365; no leap years in-game
+  for (let m = 0; m < t.month - 1; m++) days += MONTH_DAYS[m] ?? 30;
+  return days * 24 + t.gameHour;
 }
 
 const WORLD_EVENTS = new Set([

--- a/server/src/core/worldtime.ts
+++ b/server/src/core/worldtime.ts
@@ -20,6 +20,15 @@ const TICK_MS = 1_000;
 // million hours is a bug or an attack, not gameplay.
 const MAX_ADVANCE_HOURS = 30 * 24;
 const REASONS = new Set(['rest', 'wait', 'script']);
+// A tick is scheduled every second. A much larger gap means the process was SUSPENDED (a
+// laptop lid, a paused container, a starved box), and crediting that wall clock advances the
+// shared calendar by months in a single broadcast. Time the server was not running is not
+// time that passed in the world.
+const MAX_TICK_SEC = 60;
+// The furthest one call may roll the calendar. Nothing honest comes close -- the request path
+// refuses more than a month and the tick is now bounded above -- so this only stops a plugin
+// or a bad number from spinning the rollover loop for millions of iterations.
+const MAX_ROLL_DAYS = 3660; // ten years
 // Morrowind's calendar (Sun's Dawn is 28 days; no leap years in-game).
 const MONTH_DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
@@ -74,7 +83,7 @@ export class WorldClock {
   // Free-run: consume real elapsed time, then broadcast on the 60 s heartbeat.
   private tick(): void {
     const now = Date.now();
-    const elapsedSec = Math.max(0, (now - this.lastRealMs) / 1000);
+    const elapsedSec = Math.min(MAX_TICK_SEC, Math.max(0, (now - this.lastRealMs) / 1000));
     this.lastRealMs = now;
     if (this.ctx.state.timeScale > 0 && elapsedSec > 0) {
       this.addHours((elapsedSec * this.ctx.state.timeScale) / 3600);
@@ -89,12 +98,19 @@ export class WorldClock {
   }
 
   // Normalizing add. Hours may be fractional; day/month/year roll over the MW calendar.
+  //
+  // The hour is normalised ARITHMETICALLY before the calendar rolls, so it always lands in
+  // [0,24) no matter how large the jump. The previous shape subtracted 24 inside a guarded
+  // loop, which meant a jump past roughly 18,000 hours ran out of guard and left gameHour at
+  // a value like 221,952 -- broadcast to every client and persisted to global.json. The day
+  // count is what gets bounded now, and it is bounded high enough that nothing honest sees it.
   private addHours(hours: number): void {
     const t = this.ctx.state;
-    t.gameHour += hours;
-    let guard = 0;
-    while (t.gameHour >= 24 && guard++ < MAX_ADVANCE_HOURS + 32) {
-      t.gameHour -= 24;
+    t.gameHour += Math.max(0, hours); // never rewind: a negative would strand the hour too
+    let days = Math.floor(t.gameHour / 24);
+    t.gameHour -= days * 24;
+    if (days > MAX_ROLL_DAYS) days = MAX_ROLL_DAYS;
+    while (days-- > 0) {
       t.day += 1;
       const len = MONTH_DAYS[t.month - 1] ?? 30;
       if (t.day > len) {

--- a/server/src/core/worldtime.ts
+++ b/server/src/core/worldtime.ts
@@ -29,8 +29,10 @@ const MAX_TICK_SEC = 60;
 // refuses more than a month and the tick is now bounded above -- so this only stops a plugin
 // or a bad number from spinning the rollover loop for millions of iterations.
 const MAX_ROLL_DAYS = 3660; // ten years
-// Morrowind's calendar (Sun's Dawn is 28 days; no leap years in-game).
-const MONTH_DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+// Morrowind's calendar (Sun's Dawn is 28 days; no leap years in-game). Exported because
+// worldstate.ts collapses the same calendar to compare two readings, and a second copy of
+// these numbers is a second chance for them to disagree -- which is exactly what happened.
+export const MONTH_DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 // Phase 2.5: who may skip time, and by how much.
 //   'anyone'  M7 behaviour — any rest/wait advances the shared clock for everybody

--- a/server/src/data/fsstorage.ts
+++ b/server/src/data/fsstorage.ts
@@ -175,11 +175,18 @@ export function fsStorageFrom(sharedDir: string, publicBase: string): FsStorage 
 /** S3 when the operator configured it, this server's disk otherwise. The locker is never
  *  inert now: an operator with no object-storage account still gets uploads and saves. */
 export function lockerStorageFrom(
-  cfg: { endpoint: string; region: string; bucket: string; publicBase: string;
+  cfg: { enabled?: boolean; endpoint: string; region: string; bucket: string; publicBase: string;
          accessKeyId?: string; secretAccessKey?: string },
   sharedDir: string,
   fallbackBase: string,
-): S3Storage | FsStorage {
+): S3Storage | FsStorage | undefined {
+  // OFF MEANS OFF, and it has to be decided here: every caller in both programs builds its
+  // storage through this function, and "no storage" is already the shape the rest of the code
+  // understands — Locker.enabled reads false and /saves answers saves_disabled.
+  if (cfg.enabled === false) {
+    log('info', 'locker.disabled', { note: 'players cannot store files on this server' });
+    return undefined;
+  }
   const s3 = s3FromEnv({
     endpoint: cfg.endpoint, region: cfg.region, bucket: cfg.bucket,
     ...(cfg.accessKeyId ? { accessKeyId: cfg.accessKeyId } : {}),

--- a/server/src/net/admin/api-settings.ts
+++ b/server/src/net/admin/api-settings.ts
@@ -141,6 +141,47 @@ export const DERIVED_FIELDS = [
   // them; it is the only thing that performs the change as well as recording it.
   'setup.deploymentMode', 'setup.hosting', 'setup.domain', 'setup.httpPort',
   'setup.contentProfile',
+  // WHERE THE MULTIPLAYER SERVER IS, IS NOT A QUESTION. This deployment IS the multiplayer
+  // server: the gateway supervises the worlds and each world is told the address on its own
+  // command line when it is spawned. Offering an operator a box to point their games at
+  // somebody ELSE's platform is not a configuration, it is a way to break your own server —
+  // and there is no working arrangement on the other side of it.
+  'gateway.url',
+  // The credential a world proves itself with, generated on first boot and rotated by nobody.
+  // Its own help says you should not normally set it by hand, and changing it breaks the trust
+  // between the gateway and every world it runs until they all agree again — which is a
+  // sentence describing an outage, not a setting.
+  'gateway.serverToken',
+  // PATHS INSIDE THE IMAGE, which the image owns. The binary is where the container puts the
+  // headless OpenMW; the config and user-data directories are ones this server creates and
+  // manages for it; the rest are diagnostics. None of them is a decision an operator makes,
+  // every one of them is a way to stop NPCs moving, and the failure is silent — the world
+  // simply goes still, with a dashboard that looks fine. Whoever genuinely needs to move a
+  // binary is editing config.toml on a box they have a shell on, and has the context for it.
+  'simPeer.binary', 'simPeer.configDir', 'simPeer.userDataDir',
+  'simPeer.osgStatsFile', 'simPeer.navmeshTemplate',
+  // A CELL KEY AND THREE WORLD COORDINATES ARE NOT SOMETHING ANYONE KNOWS. Nobody can type
+  // where Balmora is, the shipped default is the DEMO's cell (respawn.ts warns it is wrong for
+  // real content, which concedes the field was unusable), and a number typed slightly wrong
+  // puts every dying player inside rock or out at sea with nothing to say so.
+  //
+  // A list of named cities would need coordinates for every deployment's content, and this
+  // server cannot read them: core/esm.ts parses the TES3 header and stops, so it does not know
+  // what cells exist. Set it from the Overview instead — stand where you want it and use
+  // "respawn here" on your own row, which is by construction a place a person can stand.
+  'rules.respawnCellKey', 'rules.respawnX', 'rules.respawnY', 'rules.respawnZ',
+  // A PLAYER ALWAYS HAS AN EMAIL AND A PUBLIC HANDLE. requireProfile made that optional, and
+  // everything downstream assumed it anyway: the handle is what every social surface shows and
+  // what a typed name resolves against, so with it off the fallback for "no handle" was the
+  // ACCOUNT KEY — the login identifier, and a real name for an SSO account. An operator could
+  // turn a privacy leak on from a checkbox that read like a convenience. It is not a choice.
+  'login.requireProfile',
+  // A LOGIN BYPASS IS NOT A SETTING. allowHarnessAuth is a fixed-password door for the
+  // automated browser tests; its own help text has to say "NEVER enable this on a server
+  // reachable from the internet", which is the clearest possible sign it does not belong on a
+  // page an operator clicks through. It stays reachable from config for the harness, where the
+  // person editing the file has already accepted what it is.
+  'login.allowHarnessAuth',
   // Not a question any more, anywhere: the server always supplies the game files ('serve'),
   // and per-player cloud copies belong to the game launcher. Old configs saying 'verify' are
   // still honoured at runtime; they just cannot be produced from here.
@@ -301,7 +342,15 @@ export function settingsView(dataDir: string, config: unknown): {
         ...(h?.danger ? { danger: h.danger } : {}),
       });
     }
-    sections.push({ name, label: labelFor(name), ...(SECTION_HELP[name] ? { help: SECTION_HELP[name] } : {}), fields });
+    // A SECTION WITH NOTHING TO SHOW AND NOTHING TO SAY IS NOT RENDERED. Locking a field
+    // hides it, and locking every field in a table left a bare accordion behind: a heading an
+    // operator opens, finds empty, and goes looking for the controls that used to be there.
+    // [setup] survives this because it carries help explaining that the wizard owns those
+    // answers, which is the question somebody opening it actually has. [gateway] does not:
+    // where the multiplayer server is was never a question, so there is nothing to explain.
+    if (fields.length > 0 || SECTION_HELP[name]) {
+      sections.push({ name, label: labelFor(name), ...(SECTION_HELP[name] ? { help: SECTION_HELP[name] } : {}), fields });
+    }
 
     // Nested tables become their own sections, e.g. auth.discord, so provider credentials
     // are editable instead of showing up as an "unsupported" blob.
@@ -516,6 +565,20 @@ export function applyWizard(
       next.auth = auth;
     }
   }
+
+  // EVERY SERVER THIS WIZARD SETS UP REQUIRES A PUBLIC HANDLE.
+  //
+  // Set here rather than forced in the config parser, which is where I put it first. The parser
+  // runs for EVERY deployment, including ones that already have players — turning it on under
+  // them refuses entry to every existing account without a profile until they finish
+  // onboarding. It also broke 61 tests, all of which join without one, and a blast radius that
+  // size was the change telling me it was in the wrong place.
+  //
+  // The wizard runs once, at the start, before anybody has an account to be locked out of. A
+  // deployment that predates this keeps whatever its file says; either way the toggle is gone
+  // from the settings page, because a handle is what every social surface shows and the
+  // fallback without one is the account key.
+  if (a.completed === true) merge('login', { requireProfile: true });
 
   if (a.deliveryModel === 'serve') {
     // The server is the source of truth for content, so the locker is how players get it.

--- a/server/src/net/admin/api-settings.ts
+++ b/server/src/net/admin/api-settings.ts
@@ -118,7 +118,15 @@ export const SOLO_KEEP_FIELDS: Record<string, string[]> = {
  * question to anyone who has not already answered it.
  */
 export const DERIVED_FIELDS = [
-  'locker.publicBase',
+  // locker.publicBase is NOT here. Hiding it and REFUSING it are different things, and it only
+  // ever needed the first. Refusal is for fields where a POST is an attack -- setup.completed
+  // reopens first-run setup on a live server -- but writing your own locker origin is just
+  // configuration. Refusing it created a dead end on the one path where the derivation cannot
+  // work: "internal / behind your own proxy" asks for no domain, so the base falls back to
+  // http://127.0.0.1:<port>, every player on another machine on the LAN gets save and upload
+  // URLs pointing at their OWN loopback, and the server's warning tells the operator to set a
+  // field the dashboard refused to accept. It is hidden below when a domain exists (the wizard
+  // did ask, so asking again is the restated-fact problem) and offered when one does not.
   // [setup] is the wizard's record of the answers, and only SOME of it is live configuration.
   //
   // domain, hosting, deploymentMode and contentProfile are read at runtime: they decide the
@@ -295,6 +303,12 @@ export function settingsView(dataDir: string, config: unknown): {
   const overrides = readDashboardTree(dataDir);
   const sections: SectionView[] = [];
   const soloMode = (cfg.setup as { deploymentMode?: string } | undefined)?.deploymentMode === 'single';
+  // A domain means the wizard already asked for the origin, generated the proxy config from it
+  // and issued a certificate for it, so the locker base is derived and restating it is a second
+  // chance to get it wrong. With no domain nobody was ever asked, and the derived value is
+  // loopback -- useless to anyone not sitting at the machine -- so the operator must be able
+  // to say what origin their players actually use.
+  const hasDomain = String((cfg.setup as { domain?: string } | undefined)?.domain ?? '') !== '';
 
   for (const [name, body] of Object.entries(cfg)) {
     // `stated` is a Set the loader adds for its own bookkeeping, and dashboardFallback is
@@ -323,6 +337,7 @@ export function settingsView(dataDir: string, config: unknown): {
       // already knows both facts and a field that is never sent cannot be saved by accident.
       const path = `${name}.${key}`;
       if (DERIVED_FIELDS.includes(path)) continue;
+      if (hasDomain && path === 'locker.publicBase') continue;
       if (soloMode && SOLO_HIDE_FIELDS.includes(path)) continue;
       if (soloMode && SOLO_KEEP_FIELDS[name] && !SOLO_KEEP_FIELDS[name]!.includes(key)) continue;
       const type = fieldType(value);

--- a/server/src/net/admin/help.ts
+++ b/server/src/net/admin/help.ts
@@ -59,7 +59,9 @@ export const HELP: Record<string, FieldHelp> = {
   // --- login ----------------------------------------------------------------------------
   'login.allowRegistration': { text: 'Off means nobody new can sign up; existing accounts still work. Use with an invite code for a closed group.' },
   'login.inviteCode': { text: 'When set, registration also requires this code. A simple way to run a friends-only server without managing accounts by hand.' },
-  'login.requireProfile': { text: 'Require an email and public username before a player can enter the world.' },
+  // Not offered any more — a handle is always required (see DERIVED_FIELDS). Kept because the
+  // wizard explains the same thing when it asks for the first account.
+  'login.requireProfile': { text: 'Every player sets an email and a public username before entering the world. This is always on: the username is what other players see, and without one the only name the server has for somebody is their login identifier.' },
   'login.resumeWindowSec': { text: 'How long a dropped player may silently resume their session before they have to log in again.' },
   'login.allowHarnessAuth': {
     text: 'Test-only fixed-password login used by the automated browser harness.',
@@ -174,6 +176,9 @@ export const HELP: Record<string, FieldHelp> = {
   'authority.actorSilenceSec': { text: 'How long a cell may hold NPCs without sending any movement before it is reported as stalled.' },
 
   // --- locker ---------------------------------------------------------------------------
+  'locker.enabled': {
+    text: 'Whether players may store anything on this server: their own copy of Morrowind, and their savegames. Off means uploads are refused and saves stay in the browser, which is a complete way to play — it just does not follow them to another machine. Everything below only matters while this is on.',
+  },
   'locker.endpoint': { text: 'S3-compatible endpoint (Cloudflare R2, AWS, Backblaze, MinIO). Leave empty to store uploads on this server\'s own disk instead.' },
   'locker.bucket': { text: 'Bucket name for S3 storage.' },
   'locker.region': { text: 'Bucket region. Cloudflare R2 uses "auto".' },

--- a/server/src/net/admin/routes.ts
+++ b/server/src/net/admin/routes.ts
@@ -175,6 +175,8 @@ const ACTION_ROLE: Record<string, DashboardRole> = {
   // No in-game equivalent, so nothing was gating this anywhere. It wipes a cell's contents -
   // containers, dropped items, doors, for everyone. Owner.
   resetCell: 'owner',
+  // Writes a setting, and decides where everybody on the server wakes up after dying. Owner.
+  respawnHere: 'owner',
 };
 
 export function adminRoutes(deps: AdminDeps) {

--- a/server/src/net/admin/routes.ts
+++ b/server/src/net/admin/routes.ts
@@ -1016,8 +1016,13 @@ export function adminRoutes(deps: AdminDeps) {
       if (body === undefined) return true;
       const name = String(body.name ?? '').trim();
       const password = String(body.password ?? '');
+      // '' MEANS A PLAYER, and it has to be offered here. On a password server there is no
+      // self-serve sign-up -- /auth/password only ever logs an existing account in -- so this
+      // form is where a friend's account comes from, and it could only make moderators,
+      // viewers and owners. Adding someone to your game therefore handed them your dashboard.
+      // The per-account row below has always understood '' as "no access"; creation now does too.
       const role = String(body.role ?? 'moderator');
-      if (!ROLE_SET.has(role)) { json(res, 400, { error: 'unknown role' }); return true; }
+      if (role !== '' && !ROLE_SET.has(role)) { json(res, 400, { error: 'unknown role' }); return true; }
       const why = accountNameProblem(name);
       if (why !== null) { json(res, 400, { error: `that name ${why}` }); return true; }
       const weak = passwordProblem(password, name);
@@ -1029,9 +1034,10 @@ export function adminRoutes(deps: AdminDeps) {
           : 'invalid name' });
         return true;
       }
-      await deps.accounts.setDashboardRole(name, role as DashboardRole);
+      if (role !== '') await deps.accounts.setDashboardRole(name, role as DashboardRole);
       await deps.accounts.flush();
-      log('warn', 'admin.account_created', { account: name.toLowerCase(), role, by: ctx.accountKey });
+      log('warn', 'admin.account_created',
+        { account: name.toLowerCase(), role: role || '(player)', by: ctx.accountKey });
       json(res, 200, { ok: true, name, role });
       return true;
     }

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -13,7 +13,7 @@ import type { ContentGate, EngineGate } from '../core/manifest';
 import type { Player, Peer, Roster } from '../core/players';
 import { INPUT_DRIVING_MS, PEER_POSE_FRESH_MS } from '../core/players';
 import type { HookBus } from '../plugins/loader';
-import { handleChatSend, type ChatContext } from '../core/chat';
+import { handleChatSend, serverWhisper, type ChatContext } from '../core/chat';
 import type { Social } from '../core/social';
 import type { Moderation } from '../core/moderation';
 import { TokenBucket, IpRateLimiter } from './ratelimit';
@@ -22,6 +22,22 @@ import { MSG_EVENT, MSG_PLAYER_MOVE, MSG_PLAYER_MOVE_BATCH, MSG_ACTOR_MOVE_BATCH
 import { MSG_PLAYER_INPUT, MSG_AVATAR_MOVE_BATCH, INPUT_PAYLOAD_BYTES, packInputForward, unpackAvatarMoveBatch } from '../proto/input';
 import { unpackMove } from '../proto/movement';
 import { MAX_ABS_COORD , isChargenCell, parseExterior, cellsVisible } from '../core/movement';
+
+/** Distinct cells one session may enter. Vanilla Morrowind is around 1,800 cells in total and
+ *  a long session sees a few hundred, so this is far above honest play — it exists only to
+ *  bound cell keys a client invents, which cannot be validated because the server never reads
+ *  the content that defines what cells exist. */
+const MAX_CELLS_PER_SESSION = 4096;
+
+/** Chat gets its own budget on top of limits.msgsPerSec, because chat AMPLIFIES: one inbound
+ *  line becomes one outbound event per player in the world. limits.msgsPerSec only kills the
+ *  socket ABOVE its rate, so a client sitting just under it sustained ~59 lines a second at
+ *  every player on the world indefinitely -- ~1,900 outbound events a second on a full one --
+ *  and PROTOCOL.md already promises the global tier is rate limited. Nobody sustains five
+ *  lines a second, and the burst absorbs a pasted paragraph or a client catching up, so this
+ *  is invisible to a person and ends a flood without disconnecting anybody. */
+const CHAT_PER_SEC = 5;
+const CHAT_BURST = 20;
 import { handleAvatarItemStatesBatch, handleAvatarStatsBatch, handleStateEvent, syncStateOnJoin, type StateCtx } from '../core/playerstate';
 import type { WorldState } from '../core/worldstate';
 import type { Combat } from '../core/combat';
@@ -180,6 +196,8 @@ export class Connection implements Peer {
   // The cell's actor-authority holder streams NPC batches on top of its own pose, so it
   // must not spend the same budget as everyone else's movement.
   private readonly actorMoveBucket: TokenBucket;
+  private readonly chatBucket = new TokenBucket(CHAT_PER_SEC, CHAT_BURST);
+  private chatWarned = false; // told once per flood, not once per dropped line
   private readonly openedAt = Date.now(); // join-latency origin (== the conn.open log line)
   private closeCounted = false; // exactly one omwmp_disconnects_total sample per session
 
@@ -701,6 +719,18 @@ export class Connection implements Peer {
       metrics.protocolErrors.inc({ kind: 'unknown_event' });
       return;
     }
+    if (!this.chatBucket.take(1)) {
+      // TELL them. A line that silently vanishes reads as broken chat and gets retyped,
+      // which is the one thing that makes a flood worse.
+      if (!this.chatWarned) {
+        this.chatWarned = true;
+        serverWhisper(this.player, 'You are sending messages too quickly.');
+        log('warn', 'chat.rate_limited', { ip: this.ip, player: this.player.name });
+        metrics.rateLimited.inc({ budget: 'chat' });
+      }
+      return;
+    }
+    this.chatWarned = false;
     handleChatSend(
       this.ctx.chatCtx,
       { onChat: (p, t) => this.ctx.hooks.chat({ id: p.id, name: p.name, rank: p.rank }, t) },
@@ -900,6 +930,10 @@ export class Connection implements Peer {
   // stored pose at the new position so players who never send PlayerMove (standing still
   // after a teleport) still appear in batches, then relay to ALL in-world players with
   // the sender's id added (everyone must know who entered/left their bubble).
+  /** Distinct cells this session has entered — the bound on invented cell keys. */
+  private readonly cellsSeen = new Set<string>();
+  private cellFloodLogged = false;
+
   private handleCellChange(body: LValue | undefined): void {
     const player = this.player!;
     const cellKey = body instanceof Map ? body.get('cellKey') : undefined;
@@ -915,6 +949,39 @@ export class Connection implements Peer {
       log('warn', 'conn.bad_cell_change', { ip: this.ip, player: player.name });
       return;
     }
+
+    // HOW MANY DIFFERENT CELLS ONE SESSION MAY INVENT.
+    //
+    // A cell key is checked for being a non-empty string under 128 characters and nothing
+    // else, and it cannot be checked for more: exteriors are a grid, interiors are names out
+    // of the operator's own content, and this server never reads that content. So a client is
+    // free to "enter" cells that do not exist.
+    //
+    // Each distinct key it names costs memory that is never reclaimed: an authority Cell (its
+    // occupancy order, entry times and last snapshot) and a cached empty CellDoc. The cache
+    // not being evicted is a known, deliberate trade — releasing on vacate would race with a
+    // detached quest write and silently lose it (see persist/cellstore.ts) — and that trade
+    // was priced against "every cell any player entered", i.e. bounded by the size of the map.
+    // Unvalidated keys break that bound, turning an accepted slow leak into something a signed
+    // -in player can drive.
+    //
+    // Bounded per SESSION rather than validated, because there is nothing to validate against.
+    // Vanilla Morrowind is on the order of 1,800 cells all told and a long session visits a few
+    // hundred; this is far above honest play and far below anything that hurts.
+    if (!this.cellsSeen.has(cellKey)) {
+      if (this.cellsSeen.size >= MAX_CELLS_PER_SESSION) {
+        if (!this.cellFloodLogged) {
+          this.cellFloodLogged = true;
+          log('warn', 'conn.cell_flood', {
+            ip: this.ip, player: player.name, cells: this.cellsSeen.size,
+            note: 'refusing new cells for this session; reconnecting clears it',
+          });
+        }
+        return;
+      }
+      this.cellsSeen.add(cellKey);
+    }
+
     const oldCell = player.cellKey;
 
     // TELEPORT-HOPPING, bounded without any game data.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -363,25 +363,23 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
   // Long enough to cover a host crash or page reload (engine boot is tens of seconds on a
   // cold cache) and short enough that a genuine quit does not strand guests in a dead world.
   const OWNER_DISCONNECT_GRACE_MS = opts.ownerGraceMs ?? 90_000;
-  // The whole-world player cap: one world is one peer simulating every occupied cell, so
-  // this is a memory decision as much as a policy one (see the scale ramp).
-  const MAX_WORLD_PLAYERS = 32;
-  // ONE CAP, ENFORCED AND ADVERTISED. This ceiling used to sit only inside mayJoinWorld, which
-  // answers a question about ACCESS, so a party world that was merely FULL refused its owner's
-  // 33rd friend with "this world is private" — a sentence that is not true, reads as "the host
-  // went solo or blocked you", and cannot be checked from the outside: the host sees a working
-  // world and no error. Meanwhile /status and the dashboard advertised [server].maxPlayers,
-  // which is 64 by default, so the number shown was one nobody enforced.
+  // ONE CAP, ENFORCED AND ADVERTISED — and it is the OPERATOR'S number, [server] maxPlayers.
   //
-  // Clamped here instead, once, so every consumer agrees: the advertised seat count, the
-  // SERVER_FULL refusal in connection.ts, and the admission check below.
-  if (config.server.maxPlayers > MAX_WORLD_PLAYERS) {
-    log('info', 'server.max_players_capped', {
-      configured: config.server.maxPlayers, effective: MAX_WORLD_PLAYERS,
-      note: 'one world is one peer simulating every occupied cell; this ceiling is a memory decision',
-    });
-    config.server.maxPlayers = MAX_WORLD_PLAYERS;
-  }
+  // The ceiling used to sit inside mayJoinWorld, which answers a question about ACCESS, so a
+  // party world that was merely FULL refused its owner's 33rd friend with "this world is
+  // private": untrue, and invisible to the host, who sees a working world and no error. That
+  // check is gone from there (below), which is the fix.
+  //
+  // It was briefly replaced by clamping the configured cap to a hard 32 at boot. That over-
+  // reached. The 32 was only ever a PARTY-ADMISSION rule; SERVER_FULL has always been the
+  // operator's configured number, which ships at 256. Clamping turned a party rule into a
+  // global connection cap and silently gave an operator who asked for 256 a world that took
+  // 32 — and it capped the scale ramp (s43) at half its smallest interesting step, since soak
+  // bots connect as ordinary clients and are not the `bot`-flagged dev kind humanCount skips.
+  //
+  // So there is no clamp. Capacity is enforced once, in connection.ts, against the same
+  // config.server.maxPlayers that /status and the dashboard advertise, which is what makes
+  // the advertised number and the enforced number the same number.
   const CHAT_HISTORY_KEEP = 200;
   const CHAT_HISTORY_REPLAY = 60;
   const chatCtx: ChatContext = {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,6 +15,7 @@ import { QuestRepair } from './core/quest-repair';
 import { adminRoutes as adminDashboardRoutes } from './net/admin/routes';
 import { exportDataDir, summariseMetrics } from './net/admin/ops';
 import { writeCaddyfile, launcherEnabled } from './net/admin/caddy-config';
+import { saveSection } from './net/admin/settings-store';
 import { orderedContent } from './net/admin/api-mods';
 import { notifyFromLog, type MailConfig } from './net/admin/notify';
 import { SetupToken } from './net/admin/setup-token';
@@ -994,6 +995,37 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
         case 'resetCell':
           await m7.resetCellNow(target);
           return { ok: true, message: `reset ${target}` };
+        case 'respawnHere': {
+          // WHERE SOMEBODY IS STANDING, rather than four numbers nobody knows.
+          //
+          // Respawn is a cell key plus a world-space X/Y/Z, and the settings page asked an
+          // operator to type all four. Nobody knows the grid coordinates of Balmora, and the
+          // shipped default is the DEMO's cell — respawn.ts already warns that it is wrong for
+          // real content, which is an admission that the field is unusable as it stands.
+          //
+          // A dropdown of named cities would need a table of coordinates for every deployment's
+          // content, and this server cannot read one: core/esm.ts parses the TES3 header and
+          // nothing else, so it does not know what cells exist, let alone where in them the
+          // ground is. Guessing would put players inside rock or out at sea.
+          //
+          // The player already solved it by walking there. This takes their live position,
+          // which is by construction a place a person can stand, and works for vanilla, mods
+          // and Tamriel Rebuilt alike without knowing anything about any of them.
+          if (!online) return { ok: false, message: `${target} is not online` };
+          if (!online.cellKey || !online.pose) {
+            return { ok: false, message: `${target} has not finished loading into the world yet` };
+          }
+          const at = { cellKey: online.cellKey, x: online.pose.x, y: online.pose.y, z: online.pose.z };
+          const saved = saveSection(opts.dataDir, 'rules', {
+            respawnCellKey: at.cellKey, respawnX: at.x, respawnY: at.y, respawnZ: at.z,
+          }, sharedDir);
+          if (!saved.ok) return { ok: false, message: saved.error };
+          log('warn', 'admin.respawn_moved', { ...at, from: target });
+          return {
+            ok: true,
+            message: `respawn set to where ${target} is standing (${at.cellKey}) — it applies on restart`,
+          };
+        }
         default:
           return { ok: false, message: `unknown action ${kind}` };
       }

--- a/server/test/actor.test.ts
+++ b/server/test/actor.test.ts
@@ -329,3 +329,64 @@ test('an actor leaving a cell is announced to BOTH cells, not just the one it le
 
   peer.close(); here.close(); there.close();
 });
+
+test('actor batches are rate-tiered but NEVER culled: a distant NPC must not freeze', async (t) => {
+  // PROTOCOL.md M9 draws a deliberate line: pose updates are distance-culled and get a
+  // PlayerLeaveView so the client despawns the puppet, while actor batches are tiered by
+  // RATE only and never culled -- actors have no leave-view signal, so cutting the stream
+  // freezes NPC puppets in place instead of removing them.
+  //
+  // The existing 'far player receives no actor traffic' test puts its player in a cell that
+  // is not visible at all, so it proves the CELL rule and says nothing about distance. Apply
+  // the pose path's cull to actors and every test in this file still passes while every
+  // distant NPC in the game stops moving.
+  const server = await startServer({
+    requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
+    configOverride: {
+      server: { password: PEER_PASS },
+      // interestRadius must be >= lodMidRadius (config.ts refuses otherwise). All three LOD
+      // rates are equal so stride is 1 everywhere and the ONLY variable is the cull.
+      limits: {
+        maxConnsPerIp: 16, interestRadius: 400, interestHysteresis: 0, interestMinPeers: 0,
+        lodNearRadius: 200, lodMidRadius: 400, lodNearHz: 15, lodMidHz: 15, lodFarHz: 15,
+      },
+    },
+  });
+  t.after(() => server.close());
+
+  const peer = await TestClient.simPeer(server.port, PEER_PASS, 'Peer');
+  peer.sendCellChange('0,0', 0, 0, 0);
+  await peer.waitEvent('PlayerCellChange');
+  const epoch = ((await peer.waitEvent('ActorAuthorityGrant')).value as { epoch: number }).epoch;
+
+  const near = await TestClient.connect(server.port);
+  const { playerId: nearId } = await near.joinAsNew('Near');
+  await near.waitEvent('PlayerList');
+  near.sendCellChange('0,0', 0, 0, 0);
+  await near.waitEvent('PlayerCellChange');
+
+  const far = await TestClient.connect(server.port);
+  await far.joinAsNew('Far');
+  await far.waitEvent('PlayerList');
+  // The next cell over: cell-visible, so the cell rule lets actor traffic through -- but
+  // 8192 units away, twenty times the interest radius.
+  far.sendCellChange('1,0', 8192, 0, 0);
+  await far.waitEvent('PlayerCellChange');
+
+  far.inbox.batches.length = 0;
+  peer.sendActorMoveBatch(epoch, [REF_ENTRY]);
+  const got = await far.waitActorBatch();
+  assert.deepEqual(got.batch.entries, [REF_ENTRY],
+    'a cell-visible peer beyond the interest radius must still receive actor state');
+
+  // THE CONTROL: culling really is on at this distance. Near is cell-visible to Far and
+  // stands 8192 units away, so Far must never be sent his pose. Without this, the assertion
+  // above is equally satisfied by a server with interest management switched off.
+  await new Promise((r) => setTimeout(r, 400)); // several 66 ms ticks
+  const poses = far.inbox.batches.flatMap((b) => b.entries).filter((e) => e.id === nearId);
+  assert.equal(poses.length, 0,
+    `the pose path must be culling at this distance or this test proves nothing (got ${poses.length})`);
+  peer.close();
+  near.close();
+  far.close();
+});

--- a/server/test/actor.test.ts
+++ b/server/test/actor.test.ts
@@ -95,6 +95,47 @@ test('actor authority and relay end to end', async (t) => {
     assert.equal(b.inbox.events.filter((e) => e.name === 'ActorStatsDynamic').length, 0);
   });
 
+  // WHAT AN NPC IS WEARING AND WHAT IT IS DOING are relayed state, and neither had a test.
+  // ActorEquip carries the slots a non-holder renders the NPC with; ActorAI carries the package
+  // that drives its animation and facing. Both ride the same holder+epoch chokepoint as
+  // everything else in the Actor family, so both are guarded — but a guard nobody exercises is
+  // one that can be removed by accident, and the symptom would be subtle rather than loud:
+  // guards in the wrong armour and NPCs sliding about in the wrong pose on every screen but
+  // the holder's.
+  await t.test('actor equipment and AI relay from the holder, and only from the holder', async () => {
+    const slots = { 1: 'iron_cuirass', 3: 'iron_helm' };
+    a.sendEvent('ActorEquip', { cellKey: '0,0', epoch: epochA, ref: ACTOR_REF, slots });
+    const eq = await b.waitEvent('ActorEquip');
+    assert.equal((eq.value as { ref?: unknown }).ref !== undefined, true, 'the relay names the actor');
+    assert.deepEqual((eq.value as { slots?: unknown }).slots, slots, 'and carries the slots whole');
+
+    a.sendEvent('ActorAI', { cellKey: '0,0', epoch: epochA, ref: ACTOR_REF, pkg: 'combat' });
+    const ai = await b.waitEvent('ActorAI');
+    assert.equal((ai.value as { pkg?: string }).pkg, 'combat');
+
+    // A NON-HOLDER cannot dress or command somebody else's NPCs. Bob is in the same cell and
+    // knows the live epoch, which is exactly what makes this worth checking: the only thing
+    // stopping him is the holder test.
+    b.inbox.events.length = 0;
+    b.sendEvent('ActorEquip', { cellKey: '0,0', epoch: epochA, ref: ACTOR_REF, slots: { 1: 'daedric_cuirass' } });
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: epochA, ref: ACTOR_REF, pkg: 'follow' });
+    // Fence both sockets so a slow relay cannot be mistaken for a dropped one.
+    b.sendEvent('ChatSend', { text: 'equipfence' });
+    await b.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'equipfence');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorEquip').length, 0,
+      'a non-holder dressed an NPC and the server relayed it');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0,
+      'a non-holder drove an NPC and the server relayed it');
+
+    // And a stale epoch from the REAL holder is dropped too — the handoff race guard.
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorEquip', { cellKey: '0,0', epoch: epochA + 99, ref: ACTOR_REF, slots });
+    b.sendEvent('ChatSend', { text: 'epochfence' });
+    await b.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'epochfence');
+    assert.equal(b.inbox.events.filter((e) => e.name === 'ActorEquip').length, 0,
+      'an ActorEquip from a stale epoch was relayed');
+  });
+
   await t.test('far player receives no actor traffic', async () => {
     const c = await TestClient.connect(server.port);
     await c.joinAsNew('Cara');

--- a/server/test/admin-redesign.test.ts
+++ b/server/test/admin-redesign.test.ts
@@ -666,3 +666,35 @@ test('an operator can add a PLAYER without handing them the dashboard', async (t
   const helper = await call('/login', { method: 'POST', body: { name: 'Helper', password: 'a-long-enough-passphrase' } });
   assert.equal(helper.status, 200, 'a moderator created the same way still signs in');
 });
+
+test('the locker origin is offered exactly when the wizard never asked for one', async (t) => {
+  // "Internal or behind your own proxy" captures no domain, so lockerPublicBase falls back to
+  // http://127.0.0.1:<port>. That is correct for the operator sitting at the machine and wrong
+  // for every friend on the LAN: their browser resolves it to their own loopback and every save
+  // and upload fails. The server warns and names [locker] publicBase as the fix -- so the
+  // dashboard has to accept it. It was refused, which made the warning a dead end.
+  //
+  // Two servers rather than one POST: settingsView reads the RUNNING config, and the wizard
+  // restarts the server precisely so a domain change takes effect. Asserting across a restart
+  // is what the operator actually experiences.
+  const offers = async (override: Record<string, unknown>) => {
+    const { call, token } = await boot(t, override);
+    const view = await (await call('/settings', { token })).json() as
+      { sections: { name: string; fields: { key: string }[] }[] };
+    const has = view.sections.find((x) => x.name === 'locker')?.fields.some((f) => f.key === 'publicBase');
+    return { has, call, token };
+  };
+
+  // No domain: offered, and the value the warning asks for is accepted.
+  const lan = await offers({});
+  assert.equal(lan.has, true, 'with no domain the operator must be able to say what origin players use');
+  const saved = await lan.call('/settings/locker', {
+    method: 'PUT', token: lan.token, body: { publicBase: 'http://192.168.1.50' },
+  });
+  assert.equal(saved.status, 200, `the fix the warning names must be accepted: ${await saved.text()}`);
+
+  // With a domain the wizard already asked, derived it, and issued a certificate for it.
+  const hosted = await offers({ setup: { domain: 'example.test' } });
+  assert.equal(hosted.has, false,
+    'with a domain this is derived; asking again is a second chance to get it wrong');
+});

--- a/server/test/admin-redesign.test.ts
+++ b/server/test/admin-redesign.test.ts
@@ -634,3 +634,35 @@ test('password sign-in is refused when the operator turned it off', async (t) =>
   });
   assert.equal(r.status, 403, 'the setting is the gate, not just a hidden button');
 });
+
+test('an operator can add a PLAYER without handing them the dashboard', async (t) => {
+  // On a password server there is no self-serve sign-up: /auth/password only ever logs an
+  // existing account in, and login.allowRegistration gates the SSO path alone. So this form is
+  // where a friend's account comes from -- and its role list held only viewer, moderator and
+  // owner. Adding someone to your game therefore gave them a login to your admin dashboard.
+  // '' is the same "no access" the per-account row has always understood.
+  const { call, token } = await boot(t);
+  const made = await call('/accounts/create', {
+    method: 'POST', token, body: { name: 'Friend', password: 'a-long-enough-passphrase', role: '' },
+  });
+  assert.equal(made.status, 200, `creating a player must be allowed: ${await made.text()}`);
+
+  // 1. They cannot reach the dashboard.
+  const login = await call('/login', { method: 'POST', body: { name: 'Friend', password: 'a-long-enough-passphrase' } });
+  assert.equal(login.status, 401, 'a player must not be able to sign in to the dashboard');
+
+  // 2. The control: the account really exists and really works -- otherwise "refused" above is
+  //    satisfied by never having created anything.
+  const listed = await (await call('/accounts', { token })).json() as
+    { accounts: { name: string; dashboardRole?: string | null }[] };
+  const row = listed.accounts.find((a) => a.name.toLowerCase() === 'friend');
+  assert.ok(row, 'the account must exist');
+  assert.ok(!row?.dashboardRole, `a player must hold no dashboard role, got ${row?.dashboardRole}`);
+
+  // 3. And the old behaviour still works, so this is an addition and not a swap.
+  assert.equal((await call('/accounts/create', {
+    method: 'POST', token, body: { name: 'Helper', password: 'a-long-enough-passphrase', role: 'moderator' },
+  })).status, 200);
+  const helper = await call('/login', { method: 'POST', body: { name: 'Helper', password: 'a-long-enough-passphrase' } });
+  assert.equal(helper.status, 200, 'a moderator created the same way still signs in');
+});

--- a/server/test/admin-solo-dashboard.test.ts
+++ b/server/test/admin-solo-dashboard.test.ts
@@ -727,3 +727,27 @@ test('settings with a fixed set of values are offered as a dropdown, from the pa
   assert.ok(app.includes('f.options'), 'app.js does not read the options at all');
   assert.ok(/<select[^]{0,200}data-type="string"/.test(app), 'no dropdown is rendered');
 });
+
+// THE LIVENESS MAP HAD NO SWEEP. activeSince() filters by its cutoff when it reads, so the
+// answers were always right and the map behind them only grew: one entry for every account
+// that ever made an authenticated locker or save request, kept for the life of the process. On
+// a platform that is every account that ever plays. It is pruned on the same pass that expires
+// tokens now — anything older than a token cannot appear in any answer.
+test('the who-is-playing map does not keep every account that ever signed in', () => {
+  // A short TTL so the sweep has something to do without waiting a day.
+  const s = new LockerSessionStore(50);
+  const stale = s.mint('ghost');
+  s.resolve(stale); // marks 'ghost' as seen
+  assert.equal(s.activeSince(60_000).length, 1, 'the account registered as active');
+
+  // Past the TTL, then any mint triggers the sweep.
+  const until = Date.now() + 80;
+  while (Date.now() < until) { /* the TTL is 50ms; this is short enough to just spin */ }
+  s.mint('someone-else');
+
+  const live = (s as unknown as { lastSeen: Map<string, number> }).lastSeen;
+  assert.equal(live.has('ghost'), false,
+    'an account far past the token lifetime is still held in the liveness map');
+  assert.deepEqual(s.activeSince(60_000).map((a) => a.account), [],
+    'and nothing stale is reported as playing');
+});

--- a/server/test/admin-solo-dashboard.test.ts
+++ b/server/test/admin-solo-dashboard.test.ts
@@ -137,18 +137,38 @@ test('every hidden name is a real section, not a typo', () => {
 
 // --- fields the operator is not asked for ----------------------------------------------------
 
-test('publicBase is never offered, in either mode', () => {
-  // The wizard already asked for the domain, generated the proxy config from it and got a
-  // certificate for it. Asking again under another name is a second chance to get it wrong,
-  // and every wrong answer is silent.
+test('publicBase is not offered once the server knows the origin, in either mode', () => {
+  // "Stop asking for what the server already knows" -- the wizard asked for the domain,
+  // generated the proxy config from it and got a certificate for it, so asking again under
+  // another name is a second chance to get it wrong and every wrong answer is silent.
+  //
+  // That premise is what decides it, so the test now supplies it. Held without a domain, the
+  // rule outran its own reason: "internal or behind your own proxy" asks for no domain, the
+  // base falls back to http://127.0.0.1:<port>, and every player on another machine gets save
+  // and upload URLs pointing at their OWN loopback. The server warns and names [locker]
+  // publicBase as the fix -- which the dashboard then refused to accept, leaving the operator
+  // hand-editing config.toml, the one thing this dashboard exists to avoid.
   for (const mode of ['single', 'multiplayer']) {
     const v = settingsView(mkdtempSync(join(tmpdir(), 'set-')), {
-      setup: { deploymentMode: mode }, locker: { publicBase: '', maxBytesPerAccount: 1 },
+      setup: { deploymentMode: mode, domain: 'example.test' },
+      locker: { publicBase: '', maxBytesPerAccount: 1 },
     });
     const locker = v.sections.find((s) => s.name === 'locker')!;
     assert.deepEqual(locker.fields.filter((f) => f.key === 'publicBase'), [], `shown in ${mode}`);
     assert.ok(locker.fields.some((f) => f.key === 'maxBytesPerAccount'), 'the section still renders');
   }
+});
+
+test('publicBase IS offered when no domain was ever captured', () => {
+  // The other half of the rule above: nobody was asked, so nothing is being restated, and the
+  // derived value is loopback -- useless to anyone not sitting at the machine.
+  const v = settingsView(mkdtempSync(join(tmpdir(), 'set-')), {
+    setup: { deploymentMode: 'multiplayer', domain: '' },
+    locker: { publicBase: '', maxBytesPerAccount: 1 },
+  });
+  const locker = v.sections.find((s) => s.name === 'locker')!;
+  assert.ok(locker.fields.some((f) => f.key === 'publicBase'),
+    'with no domain the operator must be able to say what origin their players use');
 });
 
 test('the shared admin token is offered in multiplayer and not in single player', () => {

--- a/server/test/admin.test.ts
+++ b/server/test/admin.test.ts
@@ -429,3 +429,43 @@ test('erasure removes everything about an account', async (t) => {
     { account: false, player: false, bans: false, identities: 0, chatLines: 0, reports: 0,
       locker: false, saves: 0, socialRows: 0 });
 });
+
+// /tp AND /tpto ACTUALLY MOVE SOMEBODY.
+//
+// Both were tested for rank gating — who may run them — and never for their effect. That
+// leaves the failure mode where an operator types /tp, is told "Teleported Victim to you", the
+// audit line records it, and the player has not moved: the command reports success from the
+// server's side of a message the client never receives. A moderator pulling somebody out of a
+// stuck spot would have no way to tell the difference between "it worked" and "nothing
+// happened", which is exactly when this command gets used.
+test('the teleport commands move the player they name', async (t) => {
+  const { server } = await boot(t, { admin: { owners: ['Owner'] } });
+  const { c: owner } = await join(server, 'Owner');
+  await server.api.world.promoteOwner('Owner');
+  const { c: victim } = await join(server, 'Victim');
+
+  // Two people, standing apart.
+  owner.sendCellChange('5,5', 100, 200, 300);
+  await owner.waitEvent('PlayerCellChange');
+  victim.sendCellChange('9,9', 10, 20, 30);
+  await victim.waitEvent('PlayerCellChange');
+
+  // /tp brings THEM to ME: the victim is told to go where the owner is standing.
+  assert.match(await slash(owner, '/tp Victim'), /Teleported Victim/);
+  const pulled = await victim.waitEvent('AdminTeleport');
+  const at = pulled.value as { cellKey: string; x: number; y: number; z: number };
+  assert.equal(at.cellKey, '5,5', `sent to ${at.cellKey}, but the owner is in 5,5`);
+  assert.deepEqual([at.x, at.y, at.z], [100, 200, 300], 'and to the exact spot, not the cell corner');
+
+  // /tpto sends ME to THEM, which is the opposite direction through the same code.
+  victim.sendCellChange('7,7', 11, 22, 33);
+  await victim.waitEvent('PlayerCellChange');
+  assert.match(await slash(owner, '/tpto Victim'), /Teleporting you/);
+  const went = await owner.waitEvent('AdminTeleport');
+  const to = went.value as { cellKey: string; x: number; y: number; z: number };
+  assert.equal(to.cellKey, '7,7', 'the operator was sent somewhere other than the target');
+  assert.deepEqual([to.x, to.y, to.z], [11, 22, 33]);
+
+  owner.close();
+  victim.close();
+});

--- a/server/test/adminweb.test.ts
+++ b/server/test/adminweb.test.ts
@@ -173,3 +173,52 @@ test('the shipped harness password is refused unless the operator opts in', asyn
   await c2.joinAsNew('Someone', 'harness-pass-1');
   c2.close();
 });
+
+test('a moderator mute silences the muted player, and nobody else', async (t) => {
+  // The store half of this is covered above, and whisper delivery is covered in
+  // whisper.test.ts -- but only with a PERSONAL mute. isMuted(listener, speaker) answers on
+  // a personal row OR a row under the server pseudo-muter, and the server half had never
+  // been driven through actual chat delivery. Swap those two arguments and the store tests
+  // still pass, the whisper test still passes, and every moderator mute silences the wrong
+  // person on say, party and global. This is the operator's main tool short of a kick.
+  const { server, base } = await boot(t);
+  const act = (kind: string, target: string) => fetch(`${base}/admin/api/action`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ kind, target, detail: '' }),
+  });
+  const heard = (c: TestClient, text: string) =>
+    c.inbox.events.filter((e) => e.name === 'ChatMessage'
+      && (e.value as { text?: string }).text === text).length;
+
+  const alice = await TestClient.connect(server.port);
+  await alice.joinAsNew('Alice');
+  await alice.waitEvent('PlayerList');
+  const bob = await TestClient.connect(server.port);
+  await bob.joinAsNew('Bob');
+  await bob.waitEvent('PlayerList');
+
+  // Control first: without it, "Alice heard nothing" is satisfied by chat being broken.
+  bob.sendEvent('ChatSend', { text: 'before the mute' });
+  await alice.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'before the mute');
+
+  assert.equal((await act('mute', 'bob')).status, 200);
+  bob.sendEvent('ChatSend', { text: 'say while muted' });
+  bob.sendEvent('ChatSend', { text: '!global while muted' });
+  // Alice keeps talking: muting Bob must not stop BOB hearing HER. That is the assertion the
+  // argument order actually turns on -- a swap silences the listener instead of the speaker.
+  alice.sendEvent('ChatSend', { text: 'can you still hear me' });
+  await bob.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'can you still hear me');
+
+  // Lifting it is the second control AND the fence: Bob's frames are ordered on his own
+  // socket, so once Alice has this one, every muted line before it has been processed.
+  assert.equal((await act('unmute', 'bob')).status, 200);
+  bob.sendEvent('ChatSend', { text: 'after the unmute' });
+  await alice.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'after the unmute');
+
+  assert.equal(heard(alice, 'say while muted'), 0, 'a server-muted player must not be heard on say');
+  assert.equal(heard(alice, 'global while muted'), 0,
+    'nor on the global tier -- the tier a flooder would reach for');
+  alice.close();
+  bob.close();
+});

--- a/server/test/chattiers.test.ts
+++ b/server/test/chattiers.test.ts
@@ -75,3 +75,41 @@ test('a bare tier prefix is treated as a typo, not an empty message', async (t) 
   a.close();
   b.close();
 });
+
+test('chat is rate limited, the flooder is told, and it refills', async (t) => {
+  // Chat is the one tier where one client's message budget is spent on everybody else: a
+  // single inbound line becomes one outbound event PER PLAYER. The general budget only
+  // disconnects ABOVE 60/s, so a flooder sitting just under it sustained ~59 lines a second
+  // at every player on the world, forever -- and PROTOCOL.md already promises the global
+  // tier is rate limited. FLOOD stays under the general budget on purpose: this must be the
+  // chat limiter refusing lines, not the connection limiter dropping the socket.
+  const world = await two(t);
+  const FLOOD = 40;
+  for (let i = 0; i < FLOOD; i++) world.a.sendEvent('ChatSend', { text: `flood ${i}` });
+
+  // 1. The flooder is TOLD. A line that silently vanishes reads as broken chat and gets
+  //    retyped, which is the one thing that makes a flood worse.
+  await world.a.waitEvent('ChatMessage', (v) => {
+    const m = v as { channel?: string; text?: string };
+    return m.channel === 'server' && /too quickly/i.test(m.text ?? '');
+  });
+
+  // 2. It REFILLS — a limiter with no way back is a mute. Retrying until a line lands both
+  //    proves that and fences: everything sent before it has been delivered to Bob.
+  const done = 'after the flood';
+  const landed = world.b.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === done);
+  const retry = setInterval(() => world.a.sendEvent('ChatSend', { text: done }), 300);
+  t.after(() => clearInterval(retry));
+  await landed;
+  clearInterval(retry);
+
+  // 3. The control: the flood was CUT, not merely announced. Without the limiter every one
+  //    of the 60 reaches Bob.
+  const heard = world.b.inbox.events.filter((e) =>
+    e.name === 'ChatMessage' && /^flood /.test((e.value as { text?: string }).text ?? '')).length;
+  assert.ok(heard < FLOOD, `every one of the ${FLOOD} flooded lines reached the other player`);
+  assert.ok(heard >= 20,
+    `only ${heard} lines got through; the burst allowance must still cover a pasted paragraph`);
+  world.a.close();
+  world.b.close();
+});

--- a/server/test/economy.test.ts
+++ b/server/test/economy.test.ts
@@ -217,3 +217,58 @@ test("a merchant's purse is canonical and shared, and deltas from two traders bo
 
   a.close(); b.close(); c.close();
 });
+
+test("a merchant restocks on the 24-hour rule, including across a month boundary", async (t) => {
+  // The restock is fBarterGoldResetDelay: the purse comes back every 24 GAME hours. To
+  // compare two readings the server collapses the calendar to a single hour count -- and
+  // that collapse assumed twelve 28-day months while the clock that produces the readings
+  // rolls the real Morrowind lengths (31/28/31/30/...). Crossing out of a 31-day month
+  // therefore made the count go BACKWARDS by up to three days, and a merchant whose restock
+  // fell due around the boundary stayed drained until the calendar caught up.
+  //
+  // Frozen scale: the only thing that may move the clock here is the explicit advance.
+  const server = await startServer({
+    requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
+    configOverride: { time: { scale: 0 }, limits: { maxConnsPerIp: 16 } },
+  });
+  t.after(() => server.close());
+  const REF = { __refnum: { index: 92, contentFile: 0 } };
+
+  // Sun's Height has 31 days. Park the clock on the last one, so one more day crosses over.
+  server.api.world.advanceTime(351);
+  const before = server.api.world.time();
+  assert.deepEqual({ day: before.day, month: before.month }, { day: 31, month: 7 },
+    'the fixture depends on landing on the last day of a 31-day month');
+
+  const a = await TestClient.connect(server.port);
+  await a.joinAsNew('Trader');
+  await a.waitEvent('PlayerList');
+  a.sendCellChange('0,0', 0, 0, 0);
+  a.sendEvent('ContainerOpen', {
+    ref: REF, cellKey: '0,0', contents: [{ id: 'iron_dagger', n: 1 }], gold: 500,
+  });
+  assert.equal(((await a.waitEvent('ContainerState')).value as { gold?: number }).gold, 500);
+
+  a.sendEvent('ContainerOpRequest', {
+    ref: REF, cellKey: '0,0', opId: 1, op: 'gold', goldDelta: -200,
+  });
+  assert.equal(((await a.waitEvent('ContainerOpResult')).value as { ok: boolean }).ok, true);
+
+  server.api.world.advanceTime(24);
+  const after = server.api.world.time();
+  assert.deepEqual({ day: after.day, month: after.month }, { day: 1, month: 8 },
+    'one day past the 31st must be the first of the next month');
+
+  // A fresh observer: an existing client would replay its own buffered ContainerState.
+  const b = await TestClient.connect(server.port);
+  await b.joinAsNew('Customer');
+  await b.waitEvent('PlayerList');
+  b.sendCellChange('0,0', 0, 0, 0);
+  b.sendEvent('ContainerOpen', { ref: REF, cellKey: '0,0', contents: [], gold: 500 });
+  const state = (await b.waitEvent('ContainerState')).value as { gold?: number };
+  assert.equal(state.gold, 500,
+    `exactly 24 game hours passed, so the purse must be back; 300 means the restock was`
+    + ' skipped because the two halves of the server disagree about how long a month is');
+  a.close();
+  b.close();
+});

--- a/server/test/moveenforce.test.ts
+++ b/server/test/moveenforce.test.ts
@@ -239,3 +239,50 @@ test('travelling between cells is never mistaken for a warp', async (t) => {
   traveller.close();
   watcher.close();
 });
+
+// A CELL KEY IS ANYTHING THE CLIENT SAYS IT IS, and each new one costs memory forever.
+//
+// It can only be checked for being a short non-empty string: exteriors are a grid, interiors
+// are names out of the operator's own content, and this server never reads that content — so
+// there is nothing to validate against. Every distinct key a client names allocates an
+// authority Cell and a cached CellDoc, and the cache is deliberately never evicted (releasing
+// it would race a detached quest write and silently lose it — see persist/cellstore.ts).
+//
+// That trade was priced against "every cell any player entered", meaning bounded by the size
+// of the map. A client inventing keys breaks the bound, so the session is bounded instead.
+test('a session cannot invent unlimited cells', async (t) => {
+  const dataDir = tmpDataDir();
+  // TWO rate limiters already stop a FAST flood, and the first two versions of this test were
+  // measuring them rather than the cap: it was disconnected with RATE for messages, then again
+  // for bytes. They are not the whole answer — a client pacing itself under both accumulates
+  // cells for as long as it stays connected, and nothing ever reclaims them — but they do mean
+  // this is a slow leak needing patience, not a burst. Both raised here so what is under test
+  // is the cell cap rather than the limiters sitting in front of it.
+  const server = await startServer({
+    requireGameData: false, dataDir, port: 0, host: '127.0.0.1',
+    configOverride: { limits: {
+      msgsPerSec: 100000, bytesPerSec: 1e9, bytesBurst: 1e9, farTravelPerMin: 0,
+    } },
+  });
+  t.after(() => server.close());
+  const c = await TestClient.connect(server.port);
+  await c.joinAsNew('Wanderer');
+  await c.waitEvent('PlayerList');
+
+  // Far beyond the cap, and far beyond any real playthrough.
+  for (let i = 0; i < 4200; i++) c.sendCellChange(`invented-${i}`, 0, 0, 0);
+
+  // Fence the socket so every one of those has certainly been processed.
+  c.sendEvent('ChatSend', { text: 'cellfence' });
+  await c.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'cellfence');
+
+  // The server stopped taking new ones rather than allocating for all 4,200. Its own view of
+  // where this player is proves it: the last accepted cell is inside the cap, not the last
+  // one sent.
+  const live = server.roster.activeForAccount('wanderer');
+  assert.ok(live, 'the player must still be connected — the cap refuses cells, not sessions');
+  const at = Number(/invented-(\d+)/.exec(live.cellKey ?? '')?.[1] ?? -1);
+  assert.ok(at >= 0 && at < 4096,
+    `the session was allowed to invent cell ${at}; the cap is 4096 and nothing evicts these`);
+  c.close();
+});

--- a/server/test/socialux.test.ts
+++ b/server/test/socialux.test.ts
@@ -241,3 +241,28 @@ test('an invite from someone you blocked is not carried', () => {
     'a block must silence the invite too, or blocking leaks who is asking for you');
   w.close();
 });
+
+// ACCEPTING AN INVITE FROM SOMEBODY IN YOUR OWN WORLD hands back where to walk to, and that
+// event had no test at all — only the cross-world routing beside it did. The whole point of an
+// invite is arriving next to the person who sent it, and the coordinates come from the server
+// because it is the only party that knows where the host actually is: a client that guessed
+// would land in the wrong place, or inside something.
+test("accepting a same-world invite returns the inviter's live position", () => {
+  const w = world();
+  const ada = w.add('ada', 'Ada');
+  const bob = w.add('bob', 'Bob');
+  w.store.addInvite('ada', 'bob', 'world', w.clock, 60_000);
+
+  w.social.handleEvent(bob, 'InviteAccept', new Map([['acct', 'ada']]) as never);
+
+  const got = w.last('bob', 'InviteAccepted');
+  assert.ok(got, 'accepting an invite in your own world must answer with somewhere to go');
+  const at = got.body as { cellKey: string; x: number; y: number; z: number };
+  assert.equal(at.cellKey, ada.cellKey, "the destination must be the INVITER's cell");
+  assert.deepEqual([at.x, at.y, at.z], [ada.pose!.x, ada.pose!.y, ada.pose!.z],
+    "and their live position - a client cannot know this, which is why the server sends it");
+
+  // Spent: an invite is not a standing pass back to somebody's side.
+  assert.equal(w.store.hasInvite('ada', 'bob', w.clock), false, 'the invite must be consumed');
+  w.close();
+});

--- a/server/test/worldaccess.test.ts
+++ b/server/test/worldaccess.test.ts
@@ -66,17 +66,16 @@ test('private world: owner in, stranger refused; party world: friends in', async
 
 // A FULL WORLD MUST NOT CLAIM TO BE A PRIVATE ONE.
 //
-// The whole-world ceiling (one peer simulates every occupied cell, so it is a memory
-// decision) used to live inside mayJoinWorld — a function that answers "may this account be
+// The ceiling used to live inside mayJoinWorld — a function that answers "may this account be
 // here", not "is there room". So the owner's 33rd friend was refused with "this world is
 // private": untrue, unfalsifiable from the player's side (it reads as the host going solo or
-// blocking them), and invisible to the host, who sees a working world and no error. Worse,
-// /status advertised [server].maxPlayers — 64 by default — so the number shown to everyone
-// was one nobody enforced, and the 32..64 window was pure misinformation.
+// blocking them), and invisible to the host, who sees a working world and no error.
 //
-// The ceiling is applied to the configured cap at boot instead, so the advertised seats, the
-// SERVER_FULL refusal and the admission check are the same number and that window is gone.
-test('the advertised player cap is the one actually enforced', async (t) => {
+// The capacity question belongs to the one place that can answer it out loud: the SERVER_FULL
+// disconnect. And the number it answers with is the OPERATOR'S — [server] maxPlayers, the same
+// one /status and the dashboard advertise. Advertised and enforced are the same number because
+// they are literally the same field, not because one was clamped to the other.
+test('the advertised player cap is the number the operator set, and the one enforced', async (t) => {
   const server = await startServer({
     requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
     configOverride: { server: { maxPlayers: 64 } },
@@ -85,8 +84,7 @@ test('the advertised player cap is the one actually enforced', async (t) => {
 
   const status = await (await fetch(`http://127.0.0.1:${server.port}/status`)).json() as
     { maxPlayers: number };
-  assert.ok(status.maxPlayers <= 32,
-    `advertised ${status.maxPlayers} seats, but a world admits at most 32 — the gap is where`
-    + ' a full world used to refuse friends with "this world is private"');
-  assert.equal(status.maxPlayers, 32, 'the configured 64 must be clamped to the world ceiling');
+  assert.equal(status.maxPlayers, 64,
+    'the operator asked for 64 seats; advertising anything else means the number shown is not'
+    + ' the number enforced, which is the gap a full world used to fill with "this world is private"');
 });

--- a/server/test/worldbrowser.test.ts
+++ b/server/test/worldbrowser.test.ts
@@ -140,3 +140,80 @@ test('the gateway credential generates itself, and both halves get the SAME one'
   const explicit = loadConfig(tmpDataDir(), { gateway: { serverToken: 'mine' } }, shared);
   assert.equal(explicit.gateway.serverToken, 'mine', 'an explicit value overrides the minted one');
 });
+
+// ---------------------------------------------------------------- the wire reply
+// Everything above tests the WorldBrowser class. The lobby a player actually SEES is the
+// reply social.ts builds from it, and that reply carries an invariant of its own: the
+// gateway's world record includes `ownerAccount` (ownerWorld matches on it), and the reply
+// is mapped field by field precisely so that key never reaches a client. A spread instead of
+// the mapping would publish every world owner's account to everyone browsing the lobby, and
+// nothing in the suite would have noticed.
+test('the lobby lists worlds without publishing their owners\' accounts', async (t) => {
+  const { createServer } = await import('node:http');
+  const { startServer } = await import('../src/server');
+  const { TestClient } = await import('./helpers');
+
+  const OWNER = 'victim@example.com';
+  const gw = createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ worlds: [{
+      id: 'w1', mode: 'public', name: "Someone's world", host: '127.0.0.1', port: 19999,
+      playerCount: 1, maxPlayers: 8, up: true, ownerAccount: OWNER,
+    }] }));
+  });
+  await new Promise<void>((r) => gw.listen(0, '127.0.0.1', r));
+  t.after(() => new Promise<void>((r) => { gw.close(() => r()); }));
+  const gwPort = (gw.address() as { port: number }).port;
+
+  const server = await startServer({
+    requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
+    configOverride: {
+      gateway: { url: `http://127.0.0.1:${gwPort}` },
+      limits: { maxConnsPerIp: 16 },
+    },
+  });
+  t.after(() => server.close());
+
+  const c = await TestClient.connect(server.port);
+  await c.joinAsNew('Browser');
+  await c.waitEvent('PlayerList');
+  c.sendEvent('WorldList', {});
+  const reply = (await c.waitEvent('WorldList')).value as {
+    error: string; myPort: number;
+    worlds: { id: string; up: boolean; ownerAccount?: string }[];
+  };
+
+  assert.equal(reply.error, '');
+  assert.equal(reply.worlds.length, 1, 'the world the gateway returned must reach the lobby');
+  assert.equal(reply.worlds[0]?.id, 'w1');
+  assert.equal(reply.worlds[0]?.ownerAccount, undefined,
+    'the owner\'s account key must never be echoed into a client');
+  assert.ok(!JSON.stringify(reply).includes(OWNER),
+    `the reply carried the owner's account: ${JSON.stringify(reply)}`);
+  // So the UI can mark the row the player is already standing in rather than offering a
+  // "join" that reconnects them to where they are.
+  assert.equal(reply.myPort, server.port);
+  c.close();
+  await c.closed;
+});
+
+test('with no gateway the lobby is told so, rather than left loading forever', async (t) => {
+  const { startServer } = await import('../src/server');
+  const { TestClient } = await import('./helpers');
+  const server = await startServer({
+    requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
+    configOverride: { limits: { maxConnsPerIp: 16 } },
+  });
+  t.after(() => server.close());
+  const c = await TestClient.connect(server.port);
+  await c.joinAsNew('Standalone');
+  await c.waitEvent('PlayerList');
+  c.sendEvent('WorldList', {});
+  // The reply is the whole point: an optional-chained call here would send nothing at all
+  // and the player would sit on "Loading worlds..." for a request that was understood.
+  const reply = (await c.waitEvent('WorldList')).value as { error: string; worlds: unknown[] };
+  assert.equal(reply.error, 'no_gateway');
+  assert.deepEqual(reply.worlds, []);
+  c.close();
+  await c.closed;
+});

--- a/server/test/worldtime.test.ts
+++ b/server/test/worldtime.test.ts
@@ -116,6 +116,22 @@ test('server-owned clock', async (t) => {
     await c.closed;
   });
 
+  await t.test('an enormous jump still leaves a readable clock', async () => {
+    // The rollover used to subtract 24 inside a guarded loop, so a jump past roughly 18,000
+    // hours ran out of guard and left gameHour at something like 221,952 -- broadcast to
+    // every client and written to global.json. Nothing in the request path can ask for that,
+    // but the plugin entry point can, and so could a tick after the host machine slept.
+    const { c } = await join(server, 'BigJump');
+    await c.waitEvent('WorldTime');
+    server.api.world.advanceTime(1e6); // over a century
+    const t2 = (await c.waitEvent('WorldTime')).value as TimeBody;
+    assert.ok(t2.gameHour >= 0 && t2.gameHour < 24, `gameHour left out of range: ${t2.gameHour}`);
+    assert.ok(t2.day >= 1 && t2.day <= 31, `day out of range: ${t2.day}`);
+    assert.ok(t2.month >= 1 && t2.month <= 12, `month out of range: ${t2.month}`);
+    c.close();
+    await c.closed;
+  });
+
   await t.test('the clock survives a restart', async () => {
     const before = server.api.world.time();
     server.api.world.advanceTime(30);
@@ -242,6 +258,67 @@ test('per-region weather authority', async (t) => {
     c.close();
     await c.closed;
   });
+});
+
+test('a world where time does not skip refuses a rest, and says so', async (t) => {
+  // [rules] timeSkip is a real gameplay rule -- one stranger must not fast-forward a hundred
+  // people into the night -- and it was only ever tested as a dashboard FIELD. What matters
+  // is the behaviour: the shared clock must not move, and the player must be TOLD. A Rest
+  // that silently does nothing gets pressed again and then reported as a bug.
+  const { server } = await boot(t, { rules: { timeSkip: 'off' } });
+  const { c: a } = await join(server, 'WouldSleep');
+  const { c: b } = await join(server, 'Bystander');
+  await a.waitEvent('WorldTime');
+  await b.waitEvent('WorldTime');
+  const before = server.api.world.time();
+
+  a.sendEvent('WorldTimeRequest', { advanceHours: 8, reason: 'rest' });
+  const refusal = (await a.waitEvent('WorldTimeRefused')).value as { reason: string };
+  assert.ok(refusal.reason.length > 0, 'the refusal must carry a reason the player can read');
+  await fence(a, b);
+  assert.deepEqual(server.api.world.time(), before, 'a refused rest must not move the clock');
+  assert.equal(b.inbox.events.filter((e) => e.name === 'WorldTime').length, 0,
+    'and it must not be broadcast to anyone else either');
+  a.close();
+  b.close();
+  await a.closed;
+  await b.closed;
+});
+
+test('a client cannot invent an unlimited number of weather regions', async (t) => {
+  // Regions are DECLARED by the client and cannot be validated -- cell->region lives in the
+  // content files this server never reads. That is the same hole the per-session cell bound
+  // closes, and it is worse here: an accepted region is a row in global.json, written to disk,
+  // and one WorldWeather event pushed at every future joiner for the life of the world.
+  // The general per-session message budget is lifted for this client only: it would kill the
+  // socket first and the test would then prove nothing about regions. A real client capped at
+  // 60 messages a second still adds thirty regions a second, so the bound is what has to hold.
+  const { server } = await boot(t, { limits: { msgsPerSec: 4000, bytesPerSec: 8_000_000, bytesBurst: 32_000_000 } });
+  const { c: a } = await join(server, 'RegionFlood');
+  const ASKED = 300; // past the 256 cap
+  for (let i = 0; i < ASKED; i++) {
+    a.sendEvent('WorldRegionChange', { region: `Invented ${i}` });
+    a.sendEvent('WorldWeather', { region: `Invented ${i}`, current: 1 });
+  }
+  // Two round trips: the weather ops are serialized on their own queue behind the socket.
+  await fence(a, a);
+  await fence(a, a);
+
+  const { c: joiner } = await join(server, 'AfterTheFlood');
+  await fence(joiner, joiner); // everything the join pushed has now been delivered
+  const regions = new Set(joiner.inbox.events
+    .filter((e) => e.name === 'WorldWeather')
+    .map((e) => (e.value as { region: string }).region));
+  assert.ok(regions.has('Invented 255'), 'regions under the cap are still tracked normally');
+  assert.ok(!regions.has('Invented 299'),
+    'a region past the cap must never be admitted -- it would be persisted and replayed forever');
+  assert.equal(regions.size, 256,
+    `a joiner was handed ${regions.size} regions; the cap is what bounds both global.json and`
+    + ' the size of every future join');
+  a.close();
+  joiner.close();
+  await a.closed;
+  await joiner.closed;
 });
 
 test('server-issued custom records', async (t) => {

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -127,6 +127,21 @@ body.vt-bare #pageTitle {
 /* The mark is wide (an infinity knot), so it gets width and keeps its own aspect; 28px and
    the AdminLTE opacity-75 dim made it read as a smudge. Full strength, sized to the bar. */
 .brand-image { width: 40px; height: auto; margin-right: .5rem; }
+
+/* THE MARK AND THE WORDMARK SIT ON ONE BASELINE. AdminLTE lays the brand out as inline
+   content, so the image and the text each aligned to whatever the line box gave them: the
+   knot rode high against a wordmark set in a serif with its own ascent, and the pair drifted
+   left of the menu icons below. A flex row with a fixed height centres both against each
+   other and against the bar, and the padding lines the mark up with the icon column of the
+   navigation rather than hanging outside it. */
+.sidebar-brand .brand-link {
+  display: flex;
+  align-items: center;
+  height: 3.5rem;
+  padding: 0 .85rem;
+}
+.sidebar-brand .brand-link .brand-image { margin: 0 .6rem 0 0; flex: 0 0 auto; }
+.sidebar-brand .brand-link .brand-text { line-height: 1; }
 /* AdminLTE sets .brand-link colour on the anchor, which wins over a bare .brand-text rule
    by specificity. Scoped here so the gold actually lands rather than only appearing to. */
 .sidebar-brand .brand-link .brand-text {
@@ -544,4 +559,32 @@ body.vt-loading .app-wrapper { display: block; }
 @media (prefers-reduced-motion: reduce) {
   .ld-glyph { animation: none; }
   .ld-fill { animation: none; width: 100%; }
+}
+
+/* THE SIDEBAR DOES NOT COLLAPSE.
+ *
+ * Removing the toggle button takes the control away, but not the STATE: AdminLTE collapses by
+ * putting `sidebar-collapse` on the body and remembers that in localStorage, so anyone who had
+ * already clicked it would come back to a stripe of unlabelled icons with nothing left on the
+ * page to undo it. It also applies the class itself below its `sidebar-expand-lg` breakpoint.
+ *
+ * So the state is neutralised rather than merely unreachable. This navigation is the only way
+ * around the dashboard, the content beside it does not reflow into anything better, and a
+ * narrow window is a reason to scroll, not to hide the menu.
+ */
+body.sidebar-collapse .app-sidebar,
+body.sidebar-collapse .app-sidebar .sidebar-brand,
+body.sidebar-collapse .app-sidebar .sidebar-wrapper {
+  --lte-sidebar-width: 250px;
+  width: 250px;
+  margin-left: 0;
+  overflow: visible;
+}
+/* AdminLTE hides the labels rather than the bar, so the width alone is not enough. */
+body.sidebar-collapse .app-sidebar .nav-link p,
+body.sidebar-collapse .app-sidebar .brand-text,
+body.sidebar-collapse .app-sidebar .nav-header {
+  display: inline-block;
+  visibility: visible;
+  opacity: 1;
 }

--- a/server/web/app.js
+++ b/server/web/app.js
@@ -2077,10 +2077,13 @@ function renderSaves(account, r) {
     ${raw(can('owner') ? html`
       <label class="btn btn-sm btn-outline-secondary mb-0">Import a save<input type="file"
         accept=".omwsave" data-saveup hidden></label>
-      <select class="form-select form-select-sm d-inline-block ms-2" style="width:auto" data-savescope>
-        <option value="solo">into single player</option>
-        <option value="mp">into multiplayer</option>
-      </select>
+      <!-- NO SCOPE CHOOSER. This server is one thing or the other — the wizard decided that,
+           it decides which PROGRAM the container runs, and the dashboard already branches on
+           it everywhere else. Asking again at the moment of an import invited an operator to
+           file a save into the half of the server nobody here is playing, where it would sit
+           looking successful and never appear in anyone's load list. -->
+      <span class="text-secondary small ms-2" data-savescope
+        data-scope="${raw(singlePlayer() ? 'solo' : 'mp')}">into ${raw(singlePlayer() ? 'single player' : 'multiplayer')}</span>
       <div class="mt-1" data-savemsg></div>` : '')}`;
 }
 
@@ -2107,7 +2110,7 @@ function wireSaves(account, box, reload) {
     const file = pick.files[0];
     if (!file) return;
     const msg = box.querySelector('[data-savemsg]');
-    const scope = box.querySelector('[data-savescope]').value;
+    const scope = box.querySelector('[data-savescope]').dataset.scope;
     if (!/\.omwsave$/i.test(file.name)) {
       msg.innerHTML = html`<span class="text-danger">A savegame is a .omwsave file.</span>`;
       return;
@@ -2230,6 +2233,9 @@ async function pageConsole() {
         <button class="btn btn-sm btn-outline-secondary" data-act="unmute" data-t="${p.name}">unmute</button>
         <button class="btn btn-sm btn-outline-danger" data-act="ban" data-t="${p.name}"
           title="Kick them and refuse the account from now on">ban</button>
+        ${raw(owner ? html`<button class="btn btn-sm btn-outline-secondary" data-act="respawnHere"
+          data-t="${p.name}"
+          title="Everyone who dies wakes up where this player is standing. Walk to the spot, then press this — it beats typing cell coordinates.">respawn here</button>` : '')}
       </td></tr>`).join('')
     : html`<tr><td colspan="5" class="vt-empty">Nobody is playing right now.</td></tr>`;
 
@@ -2365,6 +2371,17 @@ async function pageConsole() {
           body: html`<p>They are disconnected now and the account is refused from now on,
             until someone lifts the ban here.</p>`,
           danger: 'Ban',
+        });
+        if (!ok) return;
+      }
+      if (kind === 'respawnHere') {
+        // Confirmed, because it changes where EVERYONE wakes up and the person clicking it may
+        // not realise the scope from a button on one player's row.
+        const ok = await confirmAction({
+          title: 'Move the respawn point here?',
+          body: html`<p>Everyone who dies on this server will wake up where <strong>${target}</strong>
+            is standing right now, instead of the current respawn point.</p>
+            <p class="text-secondary small mb-0">It takes effect after the next restart.</p>`,
         });
         if (!ok) return;
       }

--- a/server/web/app.js
+++ b/server/web/app.js
@@ -3780,13 +3780,15 @@ async function pageAccounts() {
             <input class="form-control" id="naPass" type="password" autocomplete="new-password"></div>
           <div class="col-sm-2"><label class="form-label small">Access</label>
             <select class="form-select" id="naRole">
-              <option value="moderator" selected>moderator</option>
+              <option value="" selected>player (no dashboard)</option>
+              <option value="moderator">moderator</option>
               <option value="viewer">viewer</option>
               <option value="owner">owner</option>
             </select></div>
           <div class="col-sm-2"><button class="btn btn-primary w-100" id="naGo">Create</button></div>
         </div>
-        <div class="form-text">Creates the account and grants dashboard access in one go.
+        <div class="form-text">Creates an account someone can sign in and play with. Leave the
+          access as <b>player</b> unless you also want them in this dashboard.
           To grant access to someone who already plays here, use their row below instead.</div>
         <div id="naErr" class="text-danger small"></div>
       </div></div>` : '')}

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -35,17 +35,27 @@
      and repainted the ground in Bootstrap's stock grey over the launcher's ash. The ground
      is set in app.css, where the rest of the palette lives. -->
 <body class="layout-fixed sidebar-expand-lg">
+<script>
+  // A COLLAPSED SIDEBAR FROM AN EARLIER VISIT IS NOT HONOURED. AdminLTE remembers the state in
+  // localStorage and re-applies it before anything else runs, so an operator who clicked the
+  // old toggle once would keep arriving to a stripe of unlabelled icons — with the button that
+  // caused it now gone. Cleared here, ahead of the vendor script, so there is nothing to
+  // restore. The CSS neutralises the class as well, for the breakpoint AdminLTE applies itself.
+  try {
+    for (const k of Object.keys(localStorage)) if (/sidebar/i.test(k)) localStorage.removeItem(k);
+  } catch { /* private mode: nothing persisted to clear anyway */ }
+</script>
 <div class="app-wrapper">
 
   <!-- Top bar -->
   <nav class="app-header navbar navbar-expand">
     <div class="container-fluid">
       <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" data-lte-toggle="sidebar" href="#" role="button" aria-label="Toggle navigation">
-            <i class="bi bi-list"></i>
-          </a>
-        </li>
+        <!-- NO SIDEBAR TOGGLE. The navigation is the only way around this dashboard and it
+             fits on the screens it is used from, so collapsing it removes the way back and
+             offers nothing: the content beside it does not reflow into anything better. The
+             control also persisted its state, so one stray click left an operator with a
+             stripe of unlabelled icons on every later visit and no obvious way to undo it. -->
         <li class="nav-item d-none d-md-flex align-items-center">
           <span class="navbar-text" id="topWorld"></span>
         </li>

--- a/wasm-build/mp-scenarios/s90-perf-budget.mjs
+++ b/wasm-build/mp-scenarios/s90-perf-budget.mjs
@@ -40,7 +40,6 @@ const BASELINE = join(HERE, 'perf-baseline.json');
 // Allowed regression before failing. GL calls are deterministic for a fixed route, so this is
 // tight; it exists to absorb ordering jitter in what the culler admits, not real growth.
 const GL_TOLERANCE = 1.10;   // +10% GL calls per frame
-const BOOT_TOLERANCE = 1.25; // +25% on boot phase ratios (noisier: download and disk cache vary)
 
 // The route. Deliberately dull and fully scripted -- a perf gate that wanders is a perf gate that
 // flaps. Balmora because it is the densest ordinary exterior in the base game and the place the
@@ -85,11 +84,38 @@ export default async function run(ctx) {
   const measured = {
     glTotal: median(glSamples.map((g) => g.total)),
     glDraw: median(glSamples.map((g) => g.draw)),
-    // Boot as a RATIO of total boot, so a slow download on CI does not read as an engine
-    // regression: what we care about is the share spent after the runtime is up.
+  };
+  // bootPostRuntimeShare IS NO LONGER GATED, and the reason is worth keeping.
+  //
+  // It was a ratio "so a slow download on CI does not read as an engine regression". A ratio
+  // does not buy that. Its two halves scale differently with the machine -- before runtimeInit
+  // is download plus a single-core WebAssembly.compile, after it is game data, the ESM store
+  // and engine init -- so the quotient never cancels machine speed. Measured on ONE commit and
+  // ONE engine, changing nothing but the machine:
+  //
+  //     laptop            runtimeInit 1395  firstFrame  5998  -> 0.767
+  //     build box idle    runtimeInit 1923  firstFrame 10371  -> 0.815
+  //     build box loaded                                      -> 0.843
+  //
+  // The number moved 10% with the weather. Worse, it moves the WRONG WAY for its own purpose:
+  // make the download FASTER and the share goes UP, which this reported as a regression. It is
+  // a load detector wearing an engine-regression label, and a gate that fires on the weather
+  // teaches you to ignore the gate.
+  //
+  // What still gates are glTotal and glDraw: GL call COUNTS, machine-independent by
+  // construction, and they held at 1753/1742 and 234/232 against a baseline from ten days and
+  // an engine rebuild ago -- which is the evidence that the engine's own work has not grown.
+  //
+  // The absolutes are recorded from here on so a future shift can be ATTRIBUTED and not merely
+  // detected: the old baseline stored the ratio alone, so when it moved there was no way to
+  // tell whether the numerator grew or the denominator shrank. That is what made this
+  // unresolvable rather than merely wrong.
+  const context = {
     bootPostRuntimeShare: boot.firstFrame > 0
       ? +((boot.firstFrame - (boot.runtimeInit || 0)) / boot.firstFrame).toFixed(3)
       : 0,
+    bootRuntimeInitMs: boot.runtimeInit || 0,
+    bootPostRuntimeMs: boot.firstFrame > 0 ? boot.firstFrame - (boot.runtimeInit || 0) : 0,
   };
   const wallclock = {
     bootFirstFrameMs: boot.firstFrame,
@@ -98,12 +124,13 @@ export default async function run(ctx) {
     streamfs: JSON.parse(await c.eval('JSON.stringify(window.__streamfsStats||null)')),
   };
   ctx.log('measured (gated):', JSON.stringify(measured));
+  ctx.log('boot (recorded, NOT gated -- machine-dependent):', JSON.stringify(context));
   ctx.log('wallclock (informational, machine-dependent):', JSON.stringify(wallclock));
 
   const hadBaseline = existsSync(BASELINE);
   if (!hadBaseline || process.env.OMW_PERF_REBASELINE) {
     mkdirSync(dirname(BASELINE), { recursive: true });
-    writeFileSync(BASELINE, JSON.stringify(measured, null, 2) + '\n');
+    writeFileSync(BASELINE, JSON.stringify({ ...measured, context }, null, 2) + '\n');
     ctx.log(hadBaseline ? 'baseline REWRITTEN (OMW_PERF_REBASELINE)' : 'baseline written (first run)');
     return;
   }
@@ -118,7 +145,12 @@ export default async function run(ctx) {
   };
   check('glTotal', GL_TOLERANCE);
   check('glDraw', GL_TOLERANCE);
-  check('bootPostRuntimeShare', BOOT_TOLERANCE);
+  // No check for bootPostRuntimeShare -- see the note above the `context` block.
+  if (base.context) {
+    ctx.log(`  boot (context only): share ${context.bootPostRuntimeShare} vs `
+      + `${base.context.bootPostRuntimeShare}, post-runtime ${context.bootPostRuntimeMs}ms vs `
+      + `${base.context.bootPostRuntimeMs}ms`);
+  }
 
   assert.equal(fail.length, 0,
     'performance regressed against wasm-build/mp-scenarios/perf-baseline.json:\n  ' + fail.join('\n  ')


### PR DESCRIPTION
Nine commits since v1.3.2, found by walking the wizard and then trying to join as a friend handed the server address — not by re-reading diffs.

## What a player hits
- The **Multiplayer door was shut on a correctly configured server**: three greyed-out "Soon" buttons and "ask the operator to enable a sign-in method", on a server whose operator had enabled one. `/auth/providers` has always reported `allowPasswordLogin` beside the provider list; the launcher read only the list.
- The page **described a different server** — "upload your own Data Files" to a personal locker, on a server already serving the game to everyone.
- **Adding a friend handed them the admin dashboard.** No self-serve sign-up exists on a password server, so "add someone" is where a friend's account comes from, and its access list held only viewer/moderator/owner.

## What an operator hits
- Settings asked for what nobody can know (four respawn coordinates) and offered free text where the parser has an enum.
- The **player cap was a hidden 32** clamped over the configured number that `/status` still advertised — a 1.3.2 regression.
- The **locker origin was never offered**, so on the one path capturing no domain the base falls back to loopback and the server's own warning named a field the dashboard refused. Unreachable since 1.2.0.

## What nobody sees until it matters
- Unlimited client-invented weather regions, each persisted and replayed at every future joiner.
- Chat had no rate limit, though the protocol promised one.
- The clock's rollover gave up past ~18,000 hours and persisted an hour out of range; a suspended host credited the whole sleep to the shared calendar.
- The two halves of the server **disagreed about how long a month is**, so a merchant drained near a month boundary stayed drained for up to three game days.
- An optional browser binding sat on the first line of `onFrame`, so on any engine without it the throw took movement reporting down for the whole session.

## Coverage
Fourteen server-to-client events existed only in the source, so a coverage audit built from `PROTOCOL.md` skipped every one. Documented, and the untested ones now have tests.

The `CHANGELOG.md` entry for 1.3.2 is backfilled here — it was tagged without one.

**1050 server tests, 0 failed. 64 browser scenarios green on real OpenMW clients** (56 main sweep + 8 peer scenarios on a rebuilt engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)