### PR TITLE
Joining a friend sent you to the wrong world, or out of your own

### DIFF
--- a/openmw/files/data/scripts/mp/social.lua
+++ b/openmw/files/data/scripts/mp/social.lua
@@ -430,6 +430,7 @@ return {
                     not_friends = 'You are not friends with them.',
                     not_online = 'They are offline.',
                     blocked = 'You cannot join them.',
+                    not_open = 'Their world is not open to friends yet. Ask them to switch to Party.',
                 }
                 status = why[tostring(data.error)] or ('Could not join: ' .. tostring(data.error or '?'))
                 ui.showMessage(status)

--- a/server/src/core/social.ts
+++ b/server/src/core/social.ts
@@ -787,6 +787,12 @@ export class Social {
     const friendName = this.d.displayName(targetAcct) ?? targetAcct;
     const own = await this.worlds.ownerWorld(targetAcct);
     if (!own) return fail('not_online');
+    // ASK THE MODE HERE, where the answer costs nothing. A world admits the party only when its
+    // owner has flipped it to 'party'; the default is 'private'. Without this check the reply
+    // was ok, the client RELOADED THE PAGE into the friend's world, the door refused it, and the
+    // player was left in a terminal Failed modal outside the game they had been in -- for the
+    // ordinary case of a friend who had not opened their world yet. Refused now, in place.
+    if (own.mode !== 'party') return fail('not_open');
     player.peer.sendEvent('JoinFriend', {
       ok: true, worldId: own.id, mode: own.mode, host: own.host, port: own.port, friendName,
       ...(own.wsPath ? { wsPath: own.wsPath } : {}),

--- a/server/src/core/worldbrowser.ts
+++ b/server/src/core/worldbrowser.ts
@@ -94,7 +94,13 @@ export class WorldBrowser {
     if (!r || typeof r !== 'object' || '__httpError' in r) return undefined;
     const worlds = (r as { worlds?: unknown }).worlds;
     if (!Array.isArray(worlds)) return undefined;
-    return (worlds as WorldEntry[]).find((w) => w.ownerAccount === accountKey && w.up);
+    // THE WORLD THEY ARE IN, NOT THE FIRST ONE THEY OWN. Worlds are per CHARACTER, and a
+    // world the owner has left stays up until the idle reaper takes it -- so an owner on their
+    // second character has two up worlds, and the map lists the older one first. find() sent
+    // every friend to the stale, empty one. An occupied world is the one to join; with none
+    // occupied the first up one is the best available answer, as before.
+    const mine = (worlds as WorldEntry[]).filter((w) => w.ownerAccount === accountKey && w.up);
+    return mine.find((w) => w.playerCount > 0) ?? mine[0];
   }
 
   async create(player: Player, id: string, mode: string): Promise<{ world?: WorldEntry; error?: string }> {


### PR DESCRIPTION
Two defects on the one path that is the point of multiplayer — a friend joining a friend — found by reading it end to end.

**The wrong world.** `ownerWorld()` returned the *first* up world the friend owned. Worlds are per character and a world its owner has left stays up until the idle reaper, so an owner on their second character has two up worlds and every friend was routed to the stale, empty one. An occupied world is now preferred.

**Out of your own game.** `joinFriend` answered `ok` without looking at the destination's mode, and `ok` reloads the page into the friend's world. The default mode is `private`, so for the ordinary case — a friend who hadn't opened their world yet — the player left their game, was refused at the door, and landed in a terminal `Failed` modal. The mode was already in the reply; it's checked before the switch and the client turns the new reason into a sentence that says what to do.

Neither is covered by `s95`, which flips the host to Party before the join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)