### PR TITLE
A cell could be made permanently unenterable, and two smaller bounds

### DIFF
--- a/server/src/core/m7.ts
+++ b/server/src/core/m7.ts
@@ -78,6 +78,11 @@ export class WorldM7 {
   private recordQueue: Promise<void> = Promise.resolve();
   private recordFloodLogged = false; // said once, not once per refusal
   private resetTimer?: NodeJS.Timeout;
+  // The sweep awaits each reset and runs on a 1 s interval, but lastResetMs is only written
+  // AFTER the awaited wipe -- so a reset slower than a tick let the next tick see the old
+  // stamp and reset the same cell again: two wipes, two WorldCellReset broadcasts, two
+  // snapshots. One flag makes a tick that arrives mid-sweep a no-op.
+  private sweeping = false;
 
   constructor(private readonly ctx: M7Ctx) {
     const m7 = ctx.cells.worldM7();
@@ -271,6 +276,12 @@ export class WorldM7 {
   }
 
   private async sweepResets(): Promise<void> {
+    if (this.sweeping) return;
+    this.sweeping = true;
+    try { await this.sweepResetsOnce(); } finally { this.sweeping = false; }
+  }
+
+  private async sweepResetsOnce(): Promise<void> {
     const now = Date.now();
     for (const entry of Object.values(this.ctx.cells.worldM7().resets)) {
       if (entry.intervalSec > 0 && now - entry.lastResetMs >= entry.intervalSec * 1000) {

--- a/server/src/core/social.ts
+++ b/server/src/core/social.ts
@@ -109,6 +109,10 @@ export class Social {
   }
 
   private readonly worlds?: WorldBrowser;
+  // Reports are retained by TIME, not count, so one player could file thousands inside the
+  // window. A real report takes longer than this to write.
+  private readonly lastReportAt = new Map<AccountKey, number>();
+  private static readonly REPORT_COOLDOWN_MS = 30_000;
 
   // ------------------------------------------------------------------ presence
 
@@ -711,6 +715,13 @@ export class Social {
           this.reply(player, 'ReportPlayer', false, 'no_reason');
           return true;
         }
+        const nowMs = this.d.now();
+        const last = this.lastReportAt.get(player.accountKey) ?? 0;
+        if (nowMs - last < Social.REPORT_COOLDOWN_MS) {
+          this.reply(player, 'ReportPlayer', false, 'too_soon');
+          return true;
+        }
+        this.lastReportAt.set(player.accountKey, nowMs);
         const target = targetAcct ? this.onlinePlayer(targetAcct) : undefined;
         void this.d.report?.({
           reporter: { id: player.id, account: player.accountKey, name: player.name },

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -23,6 +23,15 @@ const MAX_RECORD_ID = 64;
 const MAX_COUNT = 10000;
 const MAX_CELL_KEY = 128;
 const MAX_CONTAINER_ENTRIES = 512;
+// A CELL'S STATE IS ONE FRAME, AND THE WIRE HAS A CEILING. WorldCellState and CellSnapshotReplace
+// carry every placed object and every tombstone in a cell in a single LSER value, and LSER
+// refuses anything past 65,536 nodes. A placed object is ~19 nodes, so around 3,400 dropped
+// items made the cell undecodable for everyone entering it, permanently, because the doc is
+// persisted. Nothing bounded either set: drops needed only inventory credit and a tombstone
+// needed only an addressable ref, which for content objects the server cannot check exists.
+// Two thousand each is far past any honest cell and leaves half the ceiling for the rest.
+const MAX_PLACED_PER_CELL = 2000;
+const MAX_DELETED_PER_CELL = 2000;
 // A single barter window cannot move more gold than the richest vendor in the game holds many
 // times over. This does not stop a player selling honestly; it bounds GRIEFING -- a negative
 // delta drains a merchant's purse for everyone in the world, and nothing else caps it.
@@ -638,8 +647,15 @@ export class WorldState {
       return;
     }
     // The drop is going ahead, so whatever credit backed it is now spent (see setInventoryDebit).
-    if (fromInventory) this.debitAcquired?.(player, recordId, count);
     const doc = await this.cells.get(cellKey);
+    // Refused BEFORE the debit: a drop that is not going ahead must not spend the credit that
+    // backed it, or the item is gone from the count and never appears on the ground.
+    if (Object.keys(doc.placed).length >= MAX_PLACED_PER_CELL) {
+      log('warn', 'world.cell_full', { cellKey, by: player.name, cap: MAX_PLACED_PER_CELL });
+      player.peer.sendEvent('ObjectSpawnRefused', { tempId, ok: false, reason: 'cell_full' });
+      return;
+    }
+    if (fromInventory) this.debitAcquired?.(player, recordId, count);
     const netId = this.cells.allocNetId();
     const placed = { netId, recordId, cellKey, x, y, z, rotZ, count, byId: player.id };
     doc.placed[netRefKey(netId)] = placed;
@@ -691,7 +707,7 @@ export class WorldState {
     delete doc.locks[ref.key];
     delete doc.doors[ref.key];
     delete doc.containers[ref.key];
-    if (!doc.deleted.includes(ref.key)) doc.deleted.push(ref.key);
+    if (!doc.deleted.includes(ref.key)) this.tombstone(doc, ref.key, cellKey, player.name);
     this.cells.markDirty(cellKey);
     this.relayCell(cellKey, 'ObjectDelete', { ...objRefToJs(ref), cellKey, byId: player.id });
   }
@@ -733,7 +749,7 @@ export class WorldState {
     delete doc.locks[ref.key];
     delete doc.doors[ref.key];
     delete doc.containers[ref.key];
-    doc.deleted.push(ref.key);
+    this.tombstone(doc, ref.key, cellKey, player.name);
     this.cells.markDirty(cellKey);
     reply(true);
     this.relayCell(cellKey, 'ObjectDelete', { ...objRefToJs(ref), cellKey, byId: player.id });
@@ -1003,6 +1019,17 @@ export class WorldState {
   // own both ends of the wire, so a reset can instead say "here is the truth, discard what
   // you have for this cell": containers restocked, disabled objects re-enabled, spawned
   // objects gone. Sent to everyone who can see the cell, including the resetter.
+  // A tombstone past the cap is dropped, not the deletion: the object is still removed from
+  // this session's view, it just will not survive a reload. That is a degraded cell with a log
+  // line, against the alternative of a cell nobody can enter.
+  private tombstone(doc: CellDoc, key: string, cellKey: string, by: string): void {
+    if (doc.deleted.length >= MAX_DELETED_PER_CELL) {
+      log('warn', 'world.tombstones_full', { cellKey, by, cap: MAX_DELETED_PER_CELL });
+      return;
+    }
+    doc.deleted.push(key);
+  }
+
   sendCellSnapshot(cellKey: string, doc: CellDoc): void {
     for (const p of this.roster.inWorld()) {
       if (!cellsVisible(p.cellKey, cellKey)) continue;


### PR DESCRIPTION
Second read of the multiplayer server for payload bounds against the wire's 65,536-node ceiling — the class of the `RecordsSync` bug.

**A cell could be made permanently unenterable.** `WorldCellState`/`CellSnapshotReplace` carry every placed object and every tombstone in one frame. ~19 nodes per placed object → ~3,400 dropped items made the cell undecodable for anyone entering it, and the doc is persisted. Nothing bounded either set: drops needed only inventory credit; tombstones needed only an addressable ref, which for content objects the server can't check exists — so invented refs grew the list without limit, and `deleted` is an array checked with `includes()`, so each op was O(n) as well. Both capped at 2,000 per cell. A drop at the cap is refused *before* its inventory credit is spent; the client already returns refused drops to inventory.

**Reports** were retained by time and never by count. One per reporter per 30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)