### PR TITLE
A friend who respawned stayed a corpse on your screen, and companions never followed anyone

### DIFF
--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -404,8 +404,13 @@ actors.handlers.MP_ActorCellChange = function(data)
         pcall(function() p.obj:sendEvent('MP_Detach', {}) end)
         puppetActors[key] = nil
     end
+    -- AN EXTERIOR KEY IS NOT A CELL NAME. teleport() takes a cell NAME (interiors) or '' for
+    -- the exterior, where the position picks the grid square; "x,y" is our own key and the
+    -- engine looked it up as a name, failed inside the pcall, and the actor never arrived --
+    -- so every NPC that walked outdoors kept standing indoors on every other screen.
+    local cellArg = data.toCellKey:match('^%-?%d+,%-?%d+$') and '' or data.toCellKey
     pcall(function()
-        obj:teleport(data.toCellKey, util.vector3(data.x or 0, data.y or 0, data.z or 0))
+        obj:teleport(cellArg, util.vector3(data.x or 0, data.y or 0, data.z or 0))
     end)
 end
 
@@ -437,15 +442,32 @@ end
 --
 -- Holder-only, like every other actor fact: two clients both announcing the same follower
 -- would fight over it, and the holder is the one whose simulation is authoritative anyway.
+local claimedFollow = {} -- refKey -> true: actors we told the server follow US while not holding
+
 function actors.noteFollow(obj, target)
     if not (obj and obj:isValid()) then return end
     local cellKey = actors.cellKeyOfObj(obj)
-    if not cellKey or not actors.isHolderOf(cellKey) then return end
+    if not cellKey then return end
     -- nil target is a real value here: it means 'stopped following', which has to travel or a
     -- dismissed companion keeps trailing everyone else forever.
     local followId = deps.playerIdOf and deps.playerIdOf(target) or nil
+    local epoch = actors.epochOf(cellKey)
+    if not actors.isHolderOf(cellKey) then
+        -- RECRUITING IS A DIALOGUE ACTION, and dialogue runs on the recruiting player's own
+        -- client -- which, on a peer-simulated world, is never the holder. Holder-only here
+        -- meant the fact was born on a non-holder and thrown away, so no companion ever
+        -- followed anyone on any screen. A non-holder may still say exactly one thing about an
+        -- actor: "this one now follows ME" (or stopped). The server holds it to that
+        -- (worldstate.ts followClaim) and relays it to the holder, who starts the package.
+        local key = refKeyOf(obj)
+        local own = deps.ownIdFn and deps.ownIdFn() or nil
+        if followId ~= nil and followId ~= own then return end
+        if followId == nil and not claimedFollow[key] then return end
+        claimedFollow[key] = (followId ~= nil) or nil
+        epoch = epoch or 0 -- a claim is not epoch-checked; the field only has to be present
+    end
     mp.sendEvent('ActorAI', {
-        cellKey = cellKey, epoch = actors.epochOf(cellKey), ref = obj, follow = followId,
+        cellKey = cellKey, epoch = epoch, ref = obj, follow = followId,
     })
 end
 
@@ -453,9 +475,44 @@ end
 -- gets their own avatar, everyone else gets the puppet standing in for that person. Applied
 -- by sending the actor a StartAIPackage event, because AI packages can only be started from
 -- the actor's own local script -- the same asymmetry that made this a client gap.
+-- playerId -> { refKey -> actor }. Companions of each player, as told by MP_ActorAI. The
+-- engine carries a follower through a door only when it follows a PLAYER; on the peer the
+-- target is an avatar (an NPC), so the follower would stop at the door and the player would
+-- walk on alone. global.lua's MP_PlayerCellChange moves these along with the avatar.
+local followersOf = {}
+
+function actors.followersOf(playerId)
+    return followersOf[playerId] or {}
+end
+
+-- The avatar body is REPLACED on a resurrect or an appearance change, and removed when the
+-- player leaves; a Follow package aimed at the old object never finishes and the follower
+-- stands still for good. Re-aim it at the new body, or release it when there is none.
+function actors.refollow(playerId, target)
+    for _, obj in pairs(followersOf[playerId] or {}) do
+        if obj:isValid() then
+            if target then
+                pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = target }) end)
+            else
+                pcall(function() obj:sendEvent('RemoveAIPackages', 'Follow') end)
+            end
+        end
+    end
+end
+
+function actors.forgetFollowers(playerId)
+    followersOf[playerId] = nil
+end
+
 actors.handlers.MP_ActorAI = function(data)
     local obj = data.ref and data.ref:isValid() and data.ref or nil
     if not obj then return end
+    local key = refKeyOf(obj)
+    for _, list in pairs(followersOf) do list[key] = nil end
+    if data.follow ~= nil then
+        followersOf[data.follow] = followersOf[data.follow] or {}
+        followersOf[data.follow][key] = obj
+    end
     local target = deps.playerObjOf and deps.playerObjOf(data.follow) or nil
     if target then
         pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = target }) end)

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -787,6 +787,7 @@ local function spawnPuppet(id, pose)
         obj:addScript('scripts/mp/puppet.lua', { playerId = id })
     end
     puppets[id] = { obj = obj, name = name }
+    if mp.isSystem and mp.isSystem() then actors.refollow(id, obj) end -- companions aim at the new body
     pushAvatarPolicy()
     applyAvatarDoc(id) -- Phase 2b: a doc that arrived before the body existed lands now
     print('[mp] puppet spawned for ' .. name .. ' (#' .. tostring(id) .. ')')
@@ -811,6 +812,7 @@ local function despawnPuppet(id)
     -- an engine handler that throws ABORTS — which took the rest of MP_PlayerLeaveWorld
     -- with it, leaving the roster mirror stale and remoteCell/lastPose still holding a
     -- player who had left. Same transient-engine-state reasoning as tryTeleport.
+    if mp.isSystem and mp.isSystem() then actors.refollow(id, nil) end -- release, re-aimed on respawn
     if p.obj:isValid() then pcall(function() p.obj:remove() end) end
     print('[mp] puppet despawned for ' .. p.name .. ' (#' .. tostring(id) .. ')')
 end
@@ -1581,6 +1583,7 @@ local eventHandlers = {
             end
         end
         despawnPuppet(data.id)
+        actors.forgetFollowers(data.id) -- gone for good: their companions stop being theirs
         remoteCell[data.id] = nil
         lastPose[data.id] = nil
         mirrorRoster()
@@ -1735,6 +1738,14 @@ local eventHandlers = {
                 if mp.isSystem and mp.isSystem() then
                     print(string.format('[mp] avatar #%d follow-teleport to (%.0f,%.0f,%.0f) ok=%s',
                         data.id, data.x, data.y, data.z, tostring(moved)))
+                    -- COMPANIONS COME THROUGH THE DOOR TOO. The engine only carries followers
+                    -- of a PLAYER across cells; this avatar is an NPC to it, so its follower
+                    -- would be left standing at the door for everyone. Same move, same spot.
+                    if moved then
+                        for _, follower in pairs(actors.followersOf(data.id)) do
+                            tryTeleport(follower, dest, util.vector3(data.x, data.y, data.z))
+                        end
+                    end
                 end
             else
                 spawnPuppet(data.id, data)
@@ -1775,7 +1786,25 @@ local eventHandlers = {
     MP_PlayerStatsDynamic = function(data)
         if not data.id or data.id == net.playerId then return end
         remoteIdentity[data.id] = remoteIdentity[data.id] or {}
+        local was = remoteIdentity[data.id].dynamic
         remoteIdentity[data.id].dynamic = { hp = data.hp, mp = data.mp, ft = data.ft }
+        -- DEATH IS ONE-WAY FOR A BODY. hp 0 killed this puppet (MP_Stats zeroes health and
+        -- the engine plays the death), and a later hp > 0 written onto a dead actor is the
+        -- corpse-with-healthy-bars MP_AvatarResurrect describes: the friend respawned, but on
+        -- every other screen they stayed a body on the floor while their poses steered a
+        -- corpse. Same answer as the peer's: replace the body. Not on the peer itself, where
+        -- AvatarResurrect already did exactly this for the avatar.
+        local revived = was and was.hp and was.hp.c <= 0 and data.hp and data.hp.c > 0
+        if revived and puppets[data.id] and not (mp.isSystem and mp.isSystem()) then
+            local pose = lastPose[data.id]
+            if pose then
+                despawnPuppet(data.id)
+                spawnPuppet(data.id, pose) -- re-applies look, equipment and these bars
+            else
+                rebuildPuppet(data.id)
+            end
+            return
+        end
         pushStatsToPuppet(data.id)
     end,
 

--- a/openmw/files/data/scripts/mp/objects.lua
+++ b/openmw/files/data/scripts/mp/objects.lua
@@ -599,6 +599,7 @@ handlers.MP_ObjectSpawnRefused = function(data)
         local why = {
             unowned = 'That drop was refused: the world does not think you are carrying it.',
             contained = 'Your account cannot place items in a shared world right now.',
+            cell_full = 'This place is too cluttered to drop anything more here.',
         }
         deps.noticeFn(why[tostring(data and data.reason or '')] or 'That drop was refused.')
     end

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -653,6 +653,12 @@ request needs a timeout and retry of its own, or the answer needs to be guarante
   With it, every server-sent event has a client handler AND every accepted inbound event is
   sent by someone. The protocol has no dead surface left.
 
+  Then it was reachable and still never fired: `noteFollow` was holder-only, and recruiting is
+  a dialogue action on the recruiting player's client -- never the holder once the peer holds
+  every cell. `ActorAI` is now the one actor fact a non-holder may state, bounded to "follows
+  ME" / "stopped" (`worldstate.ts followClaim`), and the peer carries a player's followers
+  through cell changes with the avatar, since the engine only does that for a real Player.
+
 * **AI package state cannot be read for a foreign actor** from a global script. Still true --
   it is an engine limitation -- but it is no longer a dead end. An actor's OWN local script
   can read its own packages, and `scripts/mp/companion.lua` is that route: the fact is pushed

--- a/server/src/core/social.ts
+++ b/server/src/core/social.ts
@@ -110,8 +110,9 @@ export class Social {
 
   private readonly worlds?: WorldBrowser;
   // Reports are retained by TIME, not count, so one player could file thousands inside the
-  // window. A real report takes longer than this to write.
-  private readonly lastReportAt = new Map<AccountKey, number>();
+  // window. A real report takes longer than this to write. Keyed per reporter AND target:
+  // two griefers in one minute is two reports, the same one twice is spam.
+  private readonly lastReportAt = new Map<string, number>();
   private static readonly REPORT_COOLDOWN_MS = 30_000;
 
   // ------------------------------------------------------------------ presence
@@ -716,12 +717,13 @@ export class Social {
           return true;
         }
         const nowMs = this.d.now();
-        const last = this.lastReportAt.get(player.accountKey) ?? 0;
+        const pair = `${player.accountKey}->${targetAcct ?? typed.toLowerCase()}`;
+        const last = this.lastReportAt.get(pair) ?? 0;
         if (nowMs - last < Social.REPORT_COOLDOWN_MS) {
           this.reply(player, 'ReportPlayer', false, 'too_soon');
           return true;
         }
-        this.lastReportAt.set(player.accountKey, nowMs);
+        this.lastReportAt.set(pair, nowMs);
         const target = targetAcct ? this.onlinePlayer(targetAcct) : undefined;
         void this.d.report?.({
           reporter: { id: player.id, account: player.accountKey, name: player.name },

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -431,6 +431,36 @@ export class WorldState {
     return { cellKey, ref };
   }
 
+  // THE ONE ACTOR FACT A NON-HOLDER MAY STATE: "this actor follows me" (or stopped).
+  // Recruiting a companion is a dialogue action, and dialogue runs on the recruiting player's
+  // client -- never the holder on a peer-simulated world -- so under the holder-only rule the
+  // fact died where it was born and no companion ever followed anyone. Bounded to exactly
+  // that claim: the follow target must be the sender, the sender must be near the cell, and
+  // only the player being followed may say the following stopped.
+  private readonly followedBy = new Map<string, number>(); // cellKey/refKey -> player id
+  private followClaim(player: Player, body: LTable): void {
+    const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
+    const ref = parseObjRef(body);
+    const rawFollow = body.get('follow');
+    const follow = rawFollow === undefined ? undefined : finite(rawFollow);
+    if (!cellKey || !ref || ref.kind !== 'ref' || (rawFollow !== undefined && follow !== player.id)) {
+      this.invalid(player, 'ActorAI');
+      return;
+    }
+    if (player.system || !cellsVisible(player.cellKey, cellKey)) {
+      log('warn', 'actor.dropped', { from: player.name, name: 'ActorAI', cellKey, why: 'follow claim from afar' });
+      return;
+    }
+    const k = `${cellKey}/${ref.key}`;
+    if (follow === undefined) {
+      if (this.followedBy.get(k) !== player.id) return; // not yours to dismiss
+      this.followedBy.delete(k);
+    } else {
+      this.followedBy.set(k, player.id);
+    }
+    this.relayCellExcept(cellKey, player.id, 'ActorAI', { ...lToJs(body) as Record<string, JsLike> });
+  }
+
   private async actorEvent(player: Player, name: string, body: LTable): Promise<void> {
     if (name === 'ActorSnapshot') {
       // Snapshot has no single ref; validate cell+epoch+holder directly, then store.
@@ -446,6 +476,10 @@ export class WorldState {
         return;
       }
       this.authority.setSnapshot(cellKey, { actors: lToJs(actors) as JsLike });
+      return;
+    }
+    if (name === 'ActorAI' && this.authority.holderOf(str(body.get('cellKey'), MAX_CELL_KEY) ?? '') !== player.id) {
+      this.followClaim(player, body);
       return;
     }
     const checked = this.authCheck(player, body, name);

--- a/server/test/actor.test.ts
+++ b/server/test/actor.test.ts
@@ -136,6 +136,45 @@ test('actor authority and relay end to end', async (t) => {
       'an ActorEquip from a stale epoch was relayed');
   });
 
+  // COMPANIONS. Recruiting is a dialogue action on the recruiting player's own client, which is
+  // never the holder on a peer-simulated world -- so a non-holder must be allowed to say exactly
+  // one thing about an actor: "this one follows ME" (or stopped), and nothing wider.
+  await t.test('a non-holder may claim an actor follows them, and only them', async () => {
+    const fence = async (tag: string) => {
+      b.sendEvent('ChatSend', { text: tag });
+      await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === tag);
+    };
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF, follow: bId });
+    const claim = await a.waitEvent('ActorAI');
+    assert.equal((claim.value as { follow?: number }).follow, bId, 'the holder is told who the actor follows');
+
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF, follow: aId }); // somebody else
+    await fence('claimfence1');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0,
+      'a non-holder made an NPC follow somebody else and the server relayed it');
+
+    // Only the player being followed may dismiss.
+    const d = await TestClient.connect(server.port);
+    await d.joinAsNew('Dana');
+    await d.waitEvent('PlayerList');
+    d.sendCellChange('0,0', 0, 0, 0);
+    await d.waitEvent('PlayerCellChange');
+    a.inbox.events.length = 0;
+    d.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF });
+    d.sendEvent('ChatSend', { text: 'claimfence2' });
+    await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'claimfence2');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0,
+      "a stranger dismissed somebody else's companion and the server relayed it");
+
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF });
+    const dismiss = await a.waitEvent('ActorAI');
+    assert.equal((dismiss.value as { follow?: number }).follow, undefined, 'the follower is dismissed by the one they followed');
+    d.close();
+    await a.waitEvent('PlayerLeaveWorld'); // free her per-IP connection slot before the next test connects
+  });
+
   await t.test('far player receives no actor traffic', async () => {
     const c = await TestClient.connect(server.port);
     await c.joinAsNew('Cara');


### PR DESCRIPTION
Third gameplay pass over multiplayer, reading the code as two players' engines would run it. See the commit message for the full account.

- A respawned friend stayed a corpse on every other screen (hp>0 on a dead actor is still a corpse): `MP_PlayerStatsDynamic` now rebuilds the puppet on the hp 0 → alive edge, as the peer already does for avatars.
- Companions never followed anyone: recruiting is a dialogue action on a non-holder client and the fact was dropped at both layers. `ActorAI` is now the one actor fact a non-holder may state, bounded to "follows ME"/"stopped" (`worldstate.ts followClaim`), with a test for the bounds.
- Followers stopped at doors: the peer carries a player's followers with the avatar across cells; `MP_ActorCellChange` passed an exterior "x,y" key to `teleport()` as a cell name, so any NPC walking outdoors never arrived on other screens.
- Followers re-aimed at a rebuilt avatar body / released on leave.
- Report cooldown keyed per reporter+target (fixes the moderation suite case); `cell_full` drop refusal has a player-facing line.

Checks: Lua logic runner 90/90, `actor.test.ts` 15/15 incl. new claim test, full server suite green (moderation case fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
