### PR TITLE
The avatar never drew its weapon, so no player melee ever landed

### DIFF
--- a/openmw/files/data/scripts/mp/avatar.lua
+++ b/openmw/files/data/scripts/mp/avatar.lua
@@ -109,6 +109,15 @@ return {
             -- now because combat.lua no longer forwards a real swing while the peer holds
             -- the cell -- so a blow lands exactly once, here.
             self.controls.use = bit(input.flags, 3) and 1 or 0
+            -- THE OWNER'S STANCE, OR THE USE BIT IS INERT: an attack only starts from a drawn
+            -- weapon (character.cpp, UpperBodyState::WeaponEquipped). Spell stance maps to
+            -- Nothing on purpose -- the avatar must never cast; the owner's client casts and
+            -- forwards the hit (combat.lua onPuppetSpellHit), and a casting avatar would land it
+            -- twice. So while the owner readies magic the avatar simply stands down.
+            local want = bit(input.flags, 4) and types.Actor.STANCE.Weapon or types.Actor.STANCE.Nothing
+            if types.Actor.getStance(self) ~= want then
+                pcall(function() types.Actor.setStance(self, want) end)
+            end
         end,
     },
     eventHandlers = {

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -613,7 +613,9 @@ local function avatarStreamTick(now)
                     -- bit 3: the avatar is attacking (its owner's use bit reached it). Rides
                     -- the pose flags so the owner's state batch -- and every observer's move
                     -- batch -- carries it; player.lua mirrors it as selfFlags for s67.
-                    flags = avatarUsing[id] and 8 or 0,
+                    -- bit 4: weapon drawn, so every observer's puppet shows the same posture.
+                    flags = (avatarUsing[id] and 8 or 0)
+                        + (types.Actor.getStance(p.obj) == types.Actor.STANCE.Weapon and 16 or 0),
                     animVel = animVel,
                 }
             end)

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -159,6 +159,14 @@ local function inputTick(now)
     if c.sneak then flags = flags + 2 end
     if c.jump then flags = flags + 4 end
     if (c.use and c.use ~= 0) or now < forceUseUntil then flags = flags + 8 end
+    -- THE STANCE RIDES THE INPUT, or the avatar never swings. The engine only starts an attack
+    -- from UpperBodyState::WeaponEquipped (mwmechanics/character.cpp), and nothing on the peer
+    -- ever drew the avatar's weapon: the use bit arrived at a body standing at ease and did
+    -- nothing, while combat.lua had already cancelled the local swing as the peer's job. Same
+    -- bits as poseFlags (4 weapon, 5 spell); bits 4-5 of the input byte were reserved unused.
+    local stance = types.Actor.getStance(self)
+    if stance == types.Actor.STANCE.Weapon then flags = flags + 16 end
+    if stance == types.Actor.STANCE.Spell then flags = flags + 32 end
     if mp.sendInput then
         mp.sendInput({
             seq = inputSeq,

--- a/openmw/files/data/scripts/mp/puppet.lua
+++ b/openmw/files/data/scripts/mp/puppet.lua
@@ -338,6 +338,13 @@ local function onUpdate(dt)
     -- is what turns a small correction into an overshoot.
     self.controls.run = bit(target.flags, 0) and steering and dist2d > STEER_START
     self.controls.sneak = bit(target.flags, 1)
+    -- Posture: a friend with a sword out looks like it. Purely visual here -- the puppet never
+    -- swings (its controls.use stays 0); the peer's avatar does the hitting.
+    local want = bit(target.flags, 4) and types.Actor.STANCE.Weapon
+        or (bit(target.flags, 5) and types.Actor.STANCE.Spell or types.Actor.STANCE.Nothing)
+    if types.Actor.getStance(self) ~= want then
+        pcall(function() types.Actor.setStance(self, want) end)
+    end
     local jumpEdge = bit(target.flags, 2)
     self.controls.jump = jumpEdge and not prevJump
     prevJump = jumpEdge


### PR DESCRIPTION
Phase 4C made the peer's avatar the thing that swings and cancelled the client's own swing — but nothing ever put the avatar into weapon stance, and the engine only starts an attack from `UpperBodyState::WeaponEquipped`. On a simulated world every real melee was cancelled locally and landed nowhere.

- Input frame now carries the owner's stance in bits 4–5 (reserved, unused until now); `avatar.lua` draws/sheathes to match. Spell stance → Nothing on the avatar so it never casts (the client casts and forwards; a casting avatar would double the hit).
- Avatar stream reports weapon-drawn; puppets mirror the posture (visual only, they still never swing).

Lua logic runner 90/90. See the commit message for the full account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
