### PR TITLE
The avatar aimed level: the owner's pitch never reached it

### DIFF
--- a/openmw/files/data/scripts/mp/avatar.lua
+++ b/openmw/files/data/scripts/mp/avatar.lua
@@ -64,6 +64,7 @@ local function stop()
     self.controls.movement = 0
     self.controls.sideMovement = 0
     self.controls.yawChange = 0
+    self.controls.pitchChange = 0
     self.controls.jump = false
     self.controls.use = 0
     -- Drop the modifiers too, or a coasting avatar keeps its sneak posture (and stealth)
@@ -99,6 +100,11 @@ return {
             self.controls.sideMovement = input.side or 0
             local curYaw = self.rotation:getYaw()
             self.controls.yawChange = shortestArc((input.yaw or curYaw) - curYaw)
+            -- PITCH TOO. The input has always carried it (radians, same scale as the pose) and
+            -- the avatar never applied it, so it aimed level: an arrow at a cliff-top archer, or
+            -- a swing at a rat underfoot, went out flat no matter where the owner was looking.
+            local curPitch = self.rotation:getPitch()
+            self.controls.pitchChange = (input.pitch or curPitch) - curPitch
             self.controls.run = bit(input.flags, 0)
             self.controls.sneak = bit(input.flags, 1)
             local jump = bit(input.flags, 2)


### PR DESCRIPTION
The input frame has always carried pitch; `avatar.lua` applied yaw and ignored it, so the body that swings and shoots for the player always faced the horizon. `pitchChange` now follows the owner's pitch the way `yawChange` follows yaw. Lua logic runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)