### PR TITLE
Nothing in the world ever attacked a player, and casting, item charges and repairs were free or undone

### DIFF
--- a/openmw/apps/openmw/mwmechanics/actors.cpp
+++ b/openmw/apps/openmw/mwmechanics/actors.cpp
@@ -1669,7 +1669,12 @@ namespace MWMechanics
                     }
                     if (aiActive && inProcessingRange)
                     {
-                        if (engageCombatTimerStatus == Misc::TimerStatus::Elapsed)
+                        // ...and never AS an aggressor: its AI is off, so a combat package
+                        // stacked on it would never execute but would still read as "in
+                        // combat" to everything that asks (retaliation, guards, greetings).
+                        // The template record's Fight rating must not make players hostile.
+                        const bool actorIsAvatar = MWMP::isAvatar(actor.getPtr().getCellRef().getRefNum());
+                        if (engageCombatTimerStatus == Misc::TimerStatus::Elapsed && !actorIsAvatar)
                         {
                             if (!isPlayer)
                                 adjustCommandedActor(actor.getPtr());
@@ -1680,8 +1685,16 @@ namespace MWMechanics
                                     continue;
                                 if (otherActor.getPtr() == actor.getPtr() || isPlayer) // player is not AI-controlled
                                     continue;
-                                engageCombat(
-                                    actor.getPtr(), otherActor.getPtr(), cachedAllies, otherActor.getPtr() == player);
+                                // AN AVATAR IS A PLAYER FOR AGGRESSION. engageCombat only runs the
+                                // fight-rating check when the other actor is the player, and on the
+                                // sim peer the player is its own idle dummy -- so no creature or
+                                // hostile NPC ever attacked a connected player unprovoked: cliff
+                                // racers, rats and bandits all stood and watched. Retaliation
+                                // (mechanicsmanagerimp.cpp actorAttacked) had the same blind
+                                // spot and is fixed beside this. See mwmp/puppets.hpp.
+                                const MWWorld::Ptr& other = otherActor.getPtr();
+                                engageCombat(actor.getPtr(), other, cachedAllies,
+                                    other == player || MWMP::isAvatar(other.getCellRef().getRefNum()));
                             }
                         }
                         if (mTimerUpdateHeadTrack == 0)

--- a/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -33,6 +33,7 @@
 
 #include "actor.hpp"
 #include "actors.hpp"
+#include "../mwmp/puppets.hpp"
 #include "actorutil.hpp"
 #include "aicombat.hpp"
 #include "aipursue.hpp"
@@ -1532,8 +1533,13 @@ namespace MWMechanics
         MWMechanics::CreatureStats& statsTarget = target.getClass().getCreatureStats(target);
         AiSequence& seq = statsTarget.getAiSequence();
 
+        // AN AVATAR ATTACKER IS A PLAYER ATTACKER. A connected player's body on the sim peer
+        // has its AI disabled, so its sequence is never "in combat" with anyone, and it is not
+        // the peer's own dummy player -- so an NPC struck by it never fought back. Together
+        // with engageCombat (actors.cpp) ignoring avatars, the world simply never hit a player.
+        const bool attackerIsPlayer = attacker == player || MWMP::isAvatar(attacker.getCellRef().getRefNum());
         if (!attacker.isEmpty()
-            && (attacker.getClass().getCreatureStats(attacker).getAiSequence().isInCombat(target) || attacker == player)
+            && (attacker.getClass().getCreatureStats(attacker).getAiSequence().isInCombat(target) || attackerIsPlayer)
             && !seq.isInCombat(attacker))
         {
             // Attacker is in combat with us, but we are not in combat with the attacker yet. Time to fight back.
@@ -1545,7 +1551,7 @@ namespace MWMechanics
                 bool peaceful = false;
                 const ESM::RefId& script = target.getClass().getScript(target);
                 if (!script.empty() && target.getRefData().getLocals().hasVar(script, "onpchitme")
-                    && attacker == player)
+                    && attackerIsPlayer)
                 {
                     const int fight
                         = target.getClass().getCreatureStats(target).getAiSetting(AiSetting::Fight).getModified();

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -84,6 +84,14 @@ local function actorPose(obj)
     local flags = 0
     local ok, running = pcall(function() return types.Actor.isRunning and types.Actor.isRunning(obj) end)
     if ok and running then flags = flags + 1 end
+    -- Posture (bits 4/5, the player pose's bits): an NPC fighting someone on the holder must
+    -- look like it everywhere else -- weapon out, spell readied -- or a player takes damage
+    -- from a body standing at ease. puppet.lua mirrors the stance; it still never swings.
+    local okS, stance = pcall(function() return types.Actor.getStance(obj) end)
+    if okS then
+        if stance == types.Actor.STANCE.Weapon then flags = flags + 16 end
+        if stance == types.Actor.STANCE.Spell then flags = flags + 32 end
+    end
     return {
         obj = obj,
         x = pos.x, y = pos.y, z = pos.z,

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -856,6 +856,16 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
+* **A disease caught ON THE PEER never reaches the player.** Diseases are spells in the
+  actor's spell list and the client's own list is captured and restored (above) -- but with
+  the peer resolving every melee, a diseased creature's bite lands on the AVATAR, and the
+  avatar's spell list is a one-way copy (AvatarState in, bars and item states out). The peer
+  body carries the disease and its attribute drain; the player's client never learns it, and
+  the next AvatarState refresh does not shed it either. Needs the same back-channel bars use:
+  the peer diffs the avatar's spell list, the server writes the doc, the client adds the
+  spell. Found 2026-09-10 while auditing the avatar's stance/aggression (which was the
+  reason no bite ever landed at all).
+
 * ~~**Item repair.**~~ Nothing to do, and the entry's premise was wrong. "Condition is
   per-item state on a shared object" is not what repair touches: `mwmechanics/repair.cpp`
   works entirely on the PLAYER'S OWN inventory -- it raises the item's charge, consumes the

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -856,6 +856,17 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
+* **Client-only damage is discarded while the peer owns the bars.** Health is raise-only from
+  the client (potions, rest) and lower-only from the peer (the avatar takes the hits). That
+  is right for combat, and wrong for the damage that exists only on the client's engine:
+  trapped chests and doors, scripted damage (lava, quest scripts), and drain/damage effects
+  from a spell the player casts on themselves by mistake. The client's hp drops, the server
+  ignores it, and the avatar's next report puts it back. Falls and drowning are NOT in this
+  list -- the avatar falls and drowns too, so accepting client lowers would double them,
+  which is why the rule cannot simply be relaxed. Needs the trap/script hit to be forwarded
+  to the avatar the way spell hits on puppets are (CombatSpellHit), so it lands once, there.
+  Found 2026-09-10 while fixing the magicka and item-state halves of the same rule.
+
 * **A disease caught ON THE PEER never reaches the player.** Diseases are spells in the
   actor's spell list and the client's own list is captured and restored (above) -- but with
   the peer resolving every melee, a diseased creature's bite lands on the AVATAR, and the

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -375,6 +375,29 @@ function handleInventory(ctx: StateCtx, player: Player, body: LTable): boolean {
     if (!peerStatesFresh) {
       if (Object.keys(states).length > 0) doc.itemStates = states;
       else delete doc.itemStates;
+    } else {
+      // PER FIELD, NOT WHOLESALE. Discarding the client's states entirely made three things
+      // the client alone does vanish under the avatar's next report: a cast from an
+      // enchanted item (its CHARGE dropped only on the client -- casting from items was
+      // free), a repair (CONDITION rose only on the client -- hammers did nothing), and a
+      // soul-gem recharge (charge rose). So: charge is the client's in both directions --
+      // the avatar spends it only on cast-on-strike, which its own report still lowers --
+      // and condition may be RAISED by the client (repair) while wear stays the peer's. The
+      // soul stays the peer's: the trap resolves where the kill happens, in the avatar's gem.
+      const merged: Record<string, { condition?: number; charge?: number; soul?: string }[]> = { ...(doc.itemStates ?? {}) };
+      for (const [recId, bucket] of Object.entries(states)) {
+        const have = merged[recId] ?? [];
+        merged[recId] = bucket.map((mine, i) => {
+          const theirs = have[i] ?? {};
+          const out = { ...theirs };
+          if (mine.charge !== undefined) out.charge = mine.charge;
+          if (mine.condition !== undefined && (theirs.condition === undefined || mine.condition > theirs.condition)) {
+            out.condition = mine.condition;
+          }
+          return out;
+        });
+      }
+      doc.itemStates = merged;
     }
     // Phase 4D owner->avatar sync: the peer's copy must track what the player carries --
     // a weapon picked up mid-session has to be IN the avatar's hands for 4C to compute the

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -149,7 +149,19 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
       const have = cur?.[k]; const want = have === undefined ? 0 : Math.min(v.c, have.b);
       return have === undefined ? undefined : (want > have.c + 0.5 ? { c: want, b: have.b } : undefined);
     };
-    const r = { hp: raise('hp', hp), mp: raise('mp', mp), ft: raise('ft', ft) };
+    // MAGICKA IS THE CLIENT'S IN BOTH DIRECTIONS. The avatar never casts (avatar.lua maps the
+    // spell stance to Nothing; the owner's client casts and forwards the hit), so nothing on
+    // the peer ever SPENDS magicka -- and under raise-only the cost of every spell was a
+    // "lower" claim thrown away, then overwritten by the avatar's full bar on its next
+    // report: casting was free. A spend is accepted like a restore, clamped to [0, base];
+    // the trade is that Damage Magicka landed on the avatar is re-raised by the client's next
+    // diff, which is rare, against free spells for every mage, which is constant.
+    const spend = (v: DynamicStatDoc) => {
+      const have = cur?.mp; if (have === undefined) return undefined;
+      const want = Math.max(0, Math.min(v.c, have.b));
+      return Math.abs(want - have.c) > 0.5 ? { c: want, b: have.b } : undefined;
+    };
+    const r = { hp: raise('hp', hp), mp: spend(mp), ft: raise('ft', ft) };
     if (!r.hp && !r.mp && !r.ft) return true; // nothing restored: consumed, not applied
     // Budget the HEALTH restoration (the one that decides whether you die).
     const gained = r.hp ? r.hp.c - (cur?.hp?.c ?? r.hp.c) : 0;

--- a/server/test/avataritemstates.test.ts
+++ b/server/test/avataritemstates.test.ts
@@ -64,7 +64,7 @@ test('the peer\'s item-state report lands in the doc and reaches the owner', asy
   assert.equal(states.iron_longsword?.[0]?.condition, 37, 'the worn condition must reach the owner');
 });
 
-test('while peer states are fresh the client\'s own itemStates are ignored -- counts still land', async (t) => {
+test("while peer states are fresh the client's states merge per field: repairs and spends land, wear stays the peer's", async (t) => {
   const { peer, a } = await world(t);
   drive(t, a);
   a.sendEvent('PlayerInventory', { items: [{ id: 'iron_longsword', n: 1 }] });
@@ -75,19 +75,42 @@ test('while peer states are fresh the client\'s own itemStates are ignored -- co
   t.after(() => clearInterval(reporter));
   await a.waitEvent('SelfItemStates');
 
-  // The client claims a fully repaired sword AND a new stack of gold.
+  // The client repairs the sword (condition UP: the client alone swings hammers), spends the
+  // charge of a ring (charge DOWN: the client alone casts from items), claims a soul in the
+  // gem it carries (the peer alone fills gems -- the kill resolves there), and a new stack of
+  // gold. Repair and spend must land; the soul must not; the count is the client's as before.
+  clearInterval(reporter);
+  peer.sendEvent('AvatarItemStatesBatch', {
+    entries: [{ id: a.playerId, itemStates: {
+      iron_longsword: [{ condition: 37 }], ring_of_fire: [{ charge: 100 }], misc_soulgem_common: [{}],
+    } }],
+  });
+  await a.waitEvent('SelfItemStates', (v) => Boolean((v as { itemStates?: Record<string, unknown> })?.itemStates?.ring_of_fire));
   peer.inbox.events.length = 0;
   a.sendEvent('PlayerInventory', {
-    items: [{ id: 'iron_longsword', n: 1 }, { id: 'gold_001', n: 40 }],
-    itemStates: { iron_longsword: [{ condition: 999 }] },
+    items: [{ id: 'iron_longsword', n: 1 }, { id: 'ring_of_fire', n: 1 }, { id: 'misc_soulgem_common', n: 1 }, { id: 'gold_001', n: 40 }],
+    itemStates: {
+      iron_longsword: [{ condition: 999 }], ring_of_fire: [{ charge: 10 }], misc_soulgem_common: [{ soul: 'golden_saint' }],
+    },
   });
-  // The forward to the peer carries the doc as written: peer-owned state, client-owned count.
   const st = await peer.waitEvent('AvatarState',
     (v) => (v as { id?: number })?.id === a.playerId
       && Boolean((v as { inventory?: { id: string }[] }).inventory?.some((i) => i.id === 'gold_001')));
-  const body = st.value as { itemStates?: Record<string, { condition?: number }[]> };
-  assert.equal(body.itemStates?.iron_longsword?.[0]?.condition, 37,
-    'the peer\'s reported wear must survive the client\'s repaired claim');
+  const body = st.value as { itemStates?: Record<string, { condition?: number; charge?: number; soul?: string }[]> };
+  assert.equal(body.itemStates?.iron_longsword?.[0]?.condition, 999,
+    'a repair happens only on the client and must reach the avatar, or hammers do nothing');
+  assert.equal(body.itemStates?.ring_of_fire?.[0]?.charge, 10,
+    'a cast from an item spends charge only on the client and must reach the avatar, or it is free');
+  assert.equal(body.itemStates?.misc_soulgem_common?.[0]?.soul, undefined,
+    "the soul is the peer's: the trap resolves where the kill happens");
+
+  // ...and wear reported by the peer afterwards still lowers it: the peer may hurt.
+  peer.sendEvent('AvatarItemStatesBatch', {
+    entries: [{ id: a.playerId, itemStates: { iron_longsword: [{ condition: 900 }] } }],
+  });
+  const worn = await a.waitEvent('SelfItemStates',
+    (v) => (v as { itemStates?: Record<string, { condition?: number }[]> })?.itemStates?.iron_longsword?.[0]?.condition === 900);
+  assert.ok(worn, "the peer's wear report must still land after a repair");
 });
 
 test('an idle (non-driving) player\'s states are not overwritten by the peer', async (t) => {

--- a/server/test/avatarstats.test.ts
+++ b/server/test/avatarstats.test.ts
@@ -157,6 +157,16 @@ test('a client heal reaches the peer, and sustained fake healing is refused', as
   assert.equal((restore.value as { hp?: { c?: number } }).hp?.c, 60,
     'a legitimate heal must reach the avatar, or potions do nothing');
 
+  // MAGICKA GOES DOWN TOO. The avatar never casts, so the client is the only thing that spends
+  // magicka; a cast's cost is a LOWER claim, and under raise-only it was thrown away and then
+  // refilled by the avatar's full bar -- every spell was free. A spend must reach the avatar.
+  peer.inbox.events.length = 0;
+  a.sendEvent('PlayerStatsDynamic', { ...bars(60), mp: { c: 10, b: 50 } });
+  const spend = await peer.waitEvent('AvatarRestore',
+    (v) => (v as { id?: number; mp?: unknown })?.id === a.playerId && (v as { mp?: unknown }).mp !== undefined);
+  assert.equal((spend.value as { mp?: { c?: number } }).mp?.c, 10,
+    'a magicka spend must reach the avatar, or casting is free while the peer owns the bars');
+
   // Now the cheat: claim full health over and over. The budget (2x max health per 10s) runs
   // out and further claims are ignored -- the peer's bars stand.
   peer.inbox.events.length = 0;


### PR DESCRIPTION
Fourth gameplay pass, reading the paths a fight actually takes on a peer-simulated world. Each commit carries its own account.

- **Engine (peer):** `engageCombat` ran the fight-rating check only against the peer's dummy player, and `actorAttacked` retaliated only against the dummy or an AI already in combat. No creature or hostile NPC ever attacked a player unprovoked, and none fought back when hit by a player's avatar. Both gates now treat an avatar as a player; an avatar never *initiates* engageCombat (its AI is off, and the template record's Fight rating must not make players hostile). Compiled natively (Dockerfile.simpeer --target tier2) before merge.
- **NPC posture:** actor poses carry weapon/spell stance bits; a fighting NPC no longer looks idle on other screens.
- **Magicka:** a cast's cost was a "lower" claim thrown away under the one-writer rule, and the avatar never casts — spells were free. Spends accepted, clamped to server base, pushed to the avatar. Test added.
- **Item state:** the client's states were discarded wholesale under peer freshness — casting from items was free, repairs did nothing, soul-gem recharges were undone. Per-field merge (charge client's, condition raise client's, soul peer's). Test rewritten.
- Backlog: disease caught by the avatar on the peer; trap/scripted damage on the client.

Checks: tsc clean; `avatarstats` 5/5, `avataritemstates` 5/5; full server suite 1058 (one 25 s upload test flakes only under suite concurrency, passes alone); Lua logic runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
