### PR TITLE
Levitate dragged you back to the ground: the owner's active effects never reached the avatar

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1401,6 +1401,31 @@ local eventHandlers = {
         spawnPuppet(data.id, pose)
     end,
 
+    -- The owner's temporary active effects, mirrored onto the avatar (identity.lua snapActive
+    -- says why). Applied with resistances/absorption/reflect ignored: the owner's engine has
+    -- already rolled all of that once, and this is the same body. Stackable so a second
+    -- potion of the same kind is a second instance, as it is on the owner.
+    MP_AvatarActiveSpells = function(data)
+        if not (mp.isSystem and mp.isSystem()) or not data or not data.id then return end
+        local p = puppets[data.id]
+        if not (p and p.obj and p.obj:isValid()) then return end
+        local spells = types.Actor.activeSpells(p.obj)
+        for _, sp in ipairs(data.add or {}) do
+            local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId and #(sp.effects or {}) > 0 then
+                local ok, err = pcall(function()
+                    spells:add({ id = localId, effects = sp.effects, caster = p.obj, stackable = true,
+                        ignoreResistances = true, ignoreSpellAbsorption = true, ignoreReflect = true, quiet = true })
+                end)
+                if not ok then print('[mp] avatar active effect add failed: ' .. tostring(err)) end
+            end
+        end
+        for _, sp in ipairs(data.remove or {}) do
+            local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId then pcall(function() spells:remove(localId) end) end
+        end
+    end,
+
     -- Phase 4A: a client restoration (potion/rest/heal) raised a bar; mirror it onto the
     -- avatar so the peer's next report does not overwrite the heal with the un-restored body.
     MP_AvatarRestore = function(data)
@@ -2318,6 +2343,16 @@ local eventHandlers = {
     -- Spellbook out, mapped — the sibling of mpEquipmentOut, and for the same reason: the
     -- custom-record registry is global-only, so a player-script send would put a raw local
     -- dynamic id on the wire.
+    mpActiveSpellsOut = function(data)
+        local function mapped(list)
+            local out = {}
+            for i, e in ipairs(list or {}) do
+                out[i] = { key = e.key, id = worldmp.toNet(e.id), effects = e.effects }
+            end
+            return out
+        end
+        mp.sendEvent('PlayerActiveSpells', { add = mapped(data.add), remove = mapped(data.remove) })
+    end,
     mpSpellbookOut = function(data)
         local function mapped(list)
             local out = {}

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1420,9 +1420,22 @@ local eventHandlers = {
                 if not ok then print('[mp] avatar active effect add failed: ' .. tostring(err)) end
             end
         end
+        -- remove() takes the INSTANCE id (activeSpellId), not the record id, and the peer's
+        -- instance is its own: find it by record. Every instance of that record goes, which
+        -- is the same caveat as stacking above and costs nothing real.
         for _, sp in ipairs(data.remove or {}) do
             local localId = sp.id and worldmp.toLocal(sp.id)
-            if localId then pcall(function() spells:remove(localId) end) end
+            if localId then
+                pcall(function()
+                    local victims = {}
+                    for _, active in pairs(spells) do
+                        if active.temporary and active.id == localId and active.activeSpellId then
+                            victims[#victims + 1] = active.activeSpellId
+                        end
+                    end
+                    for _, aid in ipairs(victims) do spells:remove(aid) end
+                end)
+            end
         end
     end,
 

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -21,7 +21,7 @@ local json = require('scripts.mp.json')
 local Actor = types.Actor
 local NPC = types.NPC
 
-local INTERVALS = { appearance = 1.0, equipment = 0.5, dynamic = 0.25, progression = 1.0, inventory = 2.0 }
+local INTERVALS = { appearance = 1.0, equipment = 0.5, dynamic = 0.25, progression = 1.0, inventory = 2.0, active = 0.5 }
 local INVENTORY_CAP = 512
 -- ACQUISITION REPORTING, and why it is a separate faster pass rather than a smaller INTERVAL.
 --
@@ -40,8 +40,8 @@ local ACQUIRE_INTERVAL = 0.25
 
 local identity = {}
 
-local last = { appearance = nil, equipment = nil, dynamic = nil, progression = nil, spells = nil, inventory = nil }
-local nextAt = { appearance = 0, equipment = 0, dynamic = 0, progression = 0, inventory = 0, acquire = 0 }
+local last = { appearance = nil, equipment = nil, dynamic = nil, progression = nil, spells = nil, inventory = nil, active = nil }
+local nextAt = { appearance = 0, equipment = 0, dynamic = 0, progression = 0, inventory = 0, acquire = 0, active = 0 }
 -- recordId -> count, as of the last acquisition pass. Separate from `last.inventory` because
 -- that one only advances on the slow cadence, and comparing against it would re-report the same
 -- gain every 0.25 s until the snapshot caught up.
@@ -161,6 +161,29 @@ local function snapSpells()
         set[spell.id] = true
     end
     return set
+end
+
+-- ACTIVE EFFECTS, for the avatar. Levitate, Water Walking, Fortify Speed, Chameleon, a potion,
+-- a scroll -- cast or drunk on this client and applied to THIS body only, while the peer's
+-- avatar is what physics and NPC awareness actually run against. An avatar that does not
+-- levitate drags its owner out of the sky through reconciliation; one that is not chameleoned
+-- is seen. Temporary effects only: abilities, diseases and curses ride the spellbook, and
+-- constant-effect enchantments ride equipment, so both are already on the avatar. Keyed by
+-- the engine's own instance id so two potions of the same kind are two entries.
+local function snapActive()
+    local set = {}
+    local ok = pcall(function()
+        for _, sp in pairs(Actor.activeSpells(self)) do
+            if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil then
+                local idx = {}
+                for _, e in ipairs(sp.effects or {}) do
+                    if e.index ~= nil then idx[#idx + 1] = e.index end
+                end
+                if #idx > 0 then set[tostring(sp.activeSpellId)] = { id = sp.id, effects = idx } end
+            end
+        end
+    end)
+    return ok and set or nil
 end
 
 -- Per-item state the record id cannot express: wear, remaining enchantment charge, and which
@@ -321,6 +344,27 @@ function identity.tick(now)
 
     if baselineReady then diffSend('inventory', 'PlayerInventory', snapInventory, now) end
 
+    if now >= nextAt.active then
+        nextAt.active = now + INTERVALS.active
+        local active = snapActive()
+        if active then
+            local add, remove = {}, {}
+            for key, sp in pairs(active) do
+                if not (last.active and last.active[key]) then
+                    add[#add + 1] = { key = key, id = sp.id, effects = sp.effects }
+                end
+            end
+            for key, sp in pairs(last.active or {}) do
+                if not active[key] then remove[#remove + 1] = { key = key, id = sp.id } end
+            end
+            if #add > 0 or #remove > 0 then
+                -- Through global for the record registry (toNet), like the spellbook.
+                core.sendGlobalEvent('mpActiveSpellsOut', { add = add, remove = remove })
+            end
+            last.active = active
+        end
+    end
+
     -- Report COUNT INCREASES as they happen. Only increases: a decrease is a drop, a sale or a
     -- use, and the server learns about those from the snapshot — this exists solely to stop the
     -- server's picture being stale in the direction that matters for conservation.
@@ -358,7 +402,7 @@ function identity.reset()
     -- nil, NOT {}: the next pass must re-seed the baseline rather than treat the whole restored
     -- inventory as newly acquired.
     acqCounts = nil
-    nextAt = { appearance = 0, equipment = 0, dynamic = 0, progression = 0, inventory = 0, acquire = 0 }
+    nextAt = { appearance = 0, equipment = 0, dynamic = 0, progression = 0, inventory = 0, acquire = 0, active = 0 }
     wasDead = false
     restoring = false
     pendingPhase2 = nil

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -856,6 +856,14 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
+* **A summon is cast twice, and only the peer's one fights.** With PlayerActiveSpells the
+  owner's Summon effect now reaches the avatar and the peer summons a creature that sides
+  with it, engages what the avatar engages, and is relayed to every client as a cell actor.
+  The owner's OWN engine still summons a local copy as well: a client-only actor with its own
+  AI, in no holder's snapshot, whose hits on puppets are cancelled -- a ghost that circles the
+  fight doing nothing. Conjurers see two scamps. The client-side summon should be suppressed
+  (or its actor hidden) whenever the peer holds the cell. 2026-09-11.
+
 * **Client-only damage is discarded while the peer owns the bars.** Health is raise-only from
   the client (potions, rest) and lower-only from the peer (the avatar takes the hits). That
   is right for combat, and wrong for the damage that exists only on the client's engine:

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -875,7 +875,11 @@ loot bug already fixed here.
   the next AvatarState refresh does not shed it either. Needs the same back-channel bars use:
   the peer diffs the avatar's spell list, the server writes the doc, the client adds the
   spell. Found 2026-09-10 while auditing the avatar's stance/aggression (which was the
-  reason no bite ever landed at all).
+  reason no bite ever landed at all). The same back-channel is what a hostile NPC's spell
+  needs: Paralyze, Burden, Silence, Blind, Sound land on the AVATAR (the peer is where the
+  cast resolves) and the owner's client never feels them -- the avatar stops, the pose
+  stream stops with it, and the owner sees themselves snapped in place with no idea why.
+  The owner->avatar direction is wired (PlayerActiveSpells, 2026-09-11); this is the other.
 
 * ~~**Item repair.**~~ Nothing to do, and the entry's premise was wrong. "Condition is
   per-item state on a shared object" is not what repair touches: `mwmechanics/repair.cpp`

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -559,7 +559,49 @@ export function handleAvatarItemStatesBatch(ctx: StateCtx, sender: Player, value
 
 // Returns true when `name` belongs to the M2 state family (whether or not the body
 // validated — invalid bodies are dropped with a warn, never relayed).
+// The owner's temporary active effects, for the avatar (identity.lua snapActive). Nothing is
+// stored: an effect is as long-lived as its duration, and the avatar re-derives nothing from
+// the doc. Validated for shape and bounded, then forwarded to the world peer verbatim.
+const MAX_ACTIVE_SPELL_OPS = 32;
+const MAX_EFFECT_INDEXES = 8; // ESM spells carry at most 8 effects
+type ActiveOp = { key: string; id: string; effects?: number[] };
+function handleActiveSpells(ctx: StateCtx, player: Player, body: LTable): boolean {
+  const list = (v: LValue | undefined, withEffects: boolean): ActiveOp[] | undefined => {
+    const t = tbl(v);
+    if (!t) return [];
+    if (t.size > MAX_ACTIVE_SPELL_OPS) return undefined;
+    const out: ActiveOp[] = [];
+    for (const [, ev] of t) {
+      const e = tbl(ev);
+      const kv = e?.get('key');
+      const key = typeof kv === 'string' && kv.length > 0 && kv.length <= 32 ? kv : undefined;
+      const id = e ? recordId(e.get('id')) : undefined;
+      if (!e || !key || !id) return undefined;
+      if (!withEffects) { out.push({ key, id }); continue; }
+      const fx = tbl(e.get('effects'));
+      if (!fx || fx.size === 0 || fx.size > MAX_EFFECT_INDEXES) return undefined;
+      const effects: number[] = [];
+      for (const [, iv] of fx) {
+        const i = finite(iv);
+        if (i === undefined || !Number.isInteger(i) || i < 0 || i >= MAX_EFFECT_INDEXES) return undefined;
+        effects.push(i);
+      }
+      out.push({ key, id, effects });
+    }
+    return out;
+  };
+  const add = list(body.get('add'), true);
+  const remove = list(body.get('remove'), false);
+  if (!add || !remove) return false;
+  const worldPeer = ctx.worldPeer();
+  if (worldPeer && (add.length > 0 || remove.length > 0)) {
+    worldPeer.peer.sendEvent('AvatarActiveSpells', { id: player.id, add, remove });
+  }
+  return true;
+}
+
 const HANDLERS: Record<string, (ctx: StateCtx, player: Player, body: LTable) => boolean> = {
+  PlayerActiveSpells: handleActiveSpells,
   PlayerAppearance: handleAppearance,
   PlayerEquipment: handleEquipment,
   PlayerStatsDynamic: handleStatsDynamic,

--- a/server/test/avatarstats.test.ts
+++ b/server/test/avatarstats.test.ts
@@ -177,3 +177,28 @@ test('a client heal reaches the peer, and sustained fake healing is refused', as
     `sustained fake healing was accepted ${restores} times -- a modified client would be `
     + 'immortal while the peer owns its bars');
 });
+
+// ACTIVE EFFECTS reach the avatar. Levitate, Water Walking, a potion: cast or drunk on the
+// client, applied to that body only -- and the peer's avatar is what physics and NPC awareness
+// run against. The client diffs its temporary effects; the server checks the shape and forwards.
+test("a client's active effects are forwarded to the peer for the avatar, and garbage is not", async (t) => {
+  const { peer, a } = await world(t);
+  peer.inbox.events.length = 0;
+  a.sendEvent('PlayerActiveSpells', {
+    add: [{ key: '7', id: 'levitate', effects: [0] }, { key: '8', id: 'p_water_walking_s', effects: [0, 1] }],
+    remove: [{ key: '3', id: 'chameleon' }],
+  });
+  const got = await peer.waitEvent('AvatarActiveSpells', (v) => (v as { id?: number })?.id === a.playerId);
+  const body = got.value as { add: { id: string; effects: number[] }[]; remove: { id: string }[] };
+  assert.deepEqual(body.add.map((s) => s.id), ['levitate', 'p_water_walking_s'], 'both adds reach the peer');
+  assert.deepEqual(body.add[1]!.effects, [0, 1], 'effect indexes travel whole');
+  assert.equal(body.remove[0]!.id, 'chameleon', 'the removal reaches the peer');
+
+  // Malformed: an effect index out of any spell's range is refused as a whole message.
+  peer.inbox.events.length = 0;
+  a.sendEvent('PlayerActiveSpells', { add: [{ key: '9', id: 'levitate', effects: [99] }], remove: [] });
+  a.sendEvent('PlayerActiveSpells', { add: [{ key: '10', id: 'fortify_speed', effects: [0] }], remove: [] });
+  const next = await peer.waitEvent('AvatarActiveSpells', (v) => (v as { id?: number })?.id === a.playerId);
+  assert.equal((next.value as { add: { id: string }[] }).add[0]!.id, 'fortify_speed',
+    'the malformed message was dropped, the well-formed one after it was forwarded');
+});


### PR DESCRIPTION
Self-cast spells, potions and scrolls applied only to the owner's local body; the peer's avatar (authoritative for physics and NPC awareness) never got them, so Levitate was undone by reconciliation, Chameleon hid nobody, Fortify Speed sped up nobody. The client now diffs its temporary active effects, the server validates and forwards, and the peer applies them to the avatar (removals too). Test added; tsc clean; Lua runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)