### PR TITLE
Escort quests: the pilgrim stood at the shrine on every screen but yours

### DIFF
--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -452,7 +452,7 @@ end
 -- would fight over it, and the holder is the one whose simulation is authoritative anyway.
 local claimedFollow = {} -- refKey -> true: actors we told the server follow US while not holding
 
-function actors.noteFollow(obj, target)
+function actors.noteFollow(obj, target, escort)
     if not (obj and obj:isValid()) then return end
     local cellKey = actors.cellKeyOfObj(obj)
     if not cellKey then return end
@@ -476,7 +476,20 @@ function actors.noteFollow(obj, target)
     end
     mp.sendEvent('ActorAI', {
         cellKey = cellKey, epoch = epoch, ref = obj, follow = followId,
+        escort = (followId ~= nil and type(escort) == 'table') and escort or nil,
     })
+end
+
+local function aimAt(obj, target, escort)
+    if type(escort) == 'table' and type(escort.x) == 'number' then
+        pcall(function()
+            obj:sendEvent('StartAIPackage', { type = 'Escort', target = target,
+                destPosition = util.vector3(escort.x, escort.y or 0, escort.z or 0),
+                duration = escort.duration or 0 })
+        end)
+    else
+        pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = target }) end)
+    end
 end
 
 -- ...and the receiving half. The target is resolved LOCALLY: the player who recruited them
@@ -497,12 +510,14 @@ end
 -- player leaves; a Follow package aimed at the old object never finishes and the follower
 -- stands still for good. Re-aim it at the new body, or release it when there is none.
 function actors.refollow(playerId, target)
-    for _, obj in pairs(followersOf[playerId] or {}) do
+    for _, f in pairs(followersOf[playerId] or {}) do
+        local obj = f.obj
         if obj:isValid() then
             if target then
-                pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = target }) end)
+                aimAt(obj, target, f.escort)
             else
                 pcall(function() obj:sendEvent('RemoveAIPackages', 'Follow') end)
+                pcall(function() obj:sendEvent('RemoveAIPackages', 'Escort') end)
             end
         end
     end
@@ -519,15 +534,16 @@ actors.handlers.MP_ActorAI = function(data)
     for _, list in pairs(followersOf) do list[key] = nil end
     if data.follow ~= nil then
         followersOf[data.follow] = followersOf[data.follow] or {}
-        followersOf[data.follow][key] = obj
+        followersOf[data.follow][key] = { obj = obj, escort = data.escort }
     end
     local target = deps.playerObjOf and deps.playerObjOf(data.follow) or nil
     if target then
-        pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = target }) end)
+        aimAt(obj, target, data.escort)
     else
         -- Only Follow is removed, never the whole stack: clearing everything would also cancel
         -- the combat and wander packages that make the actor an actor.
         pcall(function() obj:sendEvent('RemoveAIPackages', 'Follow') end)
+        pcall(function() obj:sendEvent('RemoveAIPackages', 'Escort') end)
     end
 end
 

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -27,17 +27,33 @@ local nextPoll = 0
 -- them, never sends a single event in its life.
 local reportedId = nil
 
-local function followedPlayer()
+local function playerAmong(packageType)
     -- getTargets rather than getActiveTarget: a follower that is momentarily fighting, or
     -- fleeing, has Follow further down its package stack and is still a companion. Asking for
     -- the ACTIVE package would drop them the instant anything else happened and re-recruit
     -- them a second later, which would flap this event at exactly the worst moment.
-    local ok, targets = pcall(function() return I.AI.getTargets('Follow') end)
+    local ok, targets = pcall(function() return I.AI.getTargets(packageType) end)
     if not ok or not targets then return nil end
     for _, t in ipairs(targets) do
         if t and t:isValid() and types.Player.objectIsInstance(t) then return t end
     end
     return nil
+end
+
+-- Follow, or Escort. An escort quest ("AIEscort player 0 x y z" from a dialogue result) is
+-- the NPC leading the player somewhere, and it runs on the same client-only path a recruit
+-- does -- so without this the pilgrim stood at the shrine on every other screen. The
+-- destination is only readable off the ACTIVE package (there is no getPackages), so an
+-- escort momentarily fighting is reported once it resumes -- one poll later, at most.
+local function followedPlayer()
+    local t = playerAmong('Follow')
+    if t then return t, nil end
+    t = playerAmong('Escort')
+    if not t then return nil, nil end
+    local okp, pkg = pcall(function() return I.AI.getActivePackage() end)
+    if not (okp and pkg and pkg.type == 'Escort' and pkg.destPosition) then return nil, nil end
+    local d = pkg.destPosition
+    return t, { x = d.x, y = d.y, z = d.z, duration = pkg.duration or 0 }
 end
 
 return {
@@ -47,16 +63,17 @@ return {
             if now < nextPoll then return end
             nextPoll = now + POLL
 
-            local target = followedPlayer()
+            local target, escort = followedPlayer()
             -- Compared by ID, not by object: two reads of the same actor are different Lua
             -- values, so comparing the objects would report a change every single tick.
-            local id = target and target.id or nil
+            -- The kind is part of the key: Follow -> Escort of the same player is a change.
+            local id = target and ((escort and 'escort:' or 'follow:') .. tostring(target.id)) or nil
             if id == reportedId then return end
             reportedId = id
 
             -- The GLOBAL script decides whether we are the cell's authority and whether this
             -- is worth putting on the wire. This script only knows a fact about itself.
-            core.sendGlobalEvent('mpActorFollow', { actor = self.object, target = target })
+            core.sendGlobalEvent('mpActorFollow', { actor = self.object, target = target, escort = escort })
         end,
     },
 }

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1783,7 +1783,7 @@ local eventHandlers = {
                     -- would be left standing at the door for everyone. Same move, same spot.
                     if moved then
                         for _, follower in pairs(actors.followersOf(data.id)) do
-                            tryTeleport(follower, dest, util.vector3(data.x, data.y, data.z))
+                            tryTeleport(follower.obj, dest, util.vector3(data.x, data.y, data.z))
                         end
                     end
                 end
@@ -2227,7 +2227,7 @@ local eventHandlers = {
     -- script cannot read AI package state for a foreign actor. This is the only route by which
     -- the fact reaches anywhere it can be acted on.
     mpActorFollow = function(data)
-        actors.noteFollow(data and data.actor, data and data.target)
+        actors.noteFollow(data and data.actor, data and data.target, data and data.escort)
     end,
 
     mpSocialTab = function(data)

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -856,6 +856,16 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
+* **Dialogue-started AiTravel never reaches the peer.** Follow and Escort now travel from
+  the recruiting client (companion.lua -> ActorAI claim), but "AITravel x y z" from a
+  dialogue result -- the guard who walks off to fetch someone, the NPC who leaves the room
+  after the conversation -- is the same client-only class and is not reported. It cannot be
+  reported the same way blind: a puppeted NPC's top package is its RECORD's own package (AI
+  off, stack static), so every wandering NPC would re-declare its own Travel once a second
+  and the peer would restart what it is already running. Needs a "this package was
+  stacked after the conversation" signal (the dialogue-close edge plus a package diff on
+  that one actor), not a poll. 2026-09-11.
+
 * **A summon is cast twice, and only the peer's one fights.** With PlayerActiveSpells the
   owner's Summon effect now reaches the avatar and the peer summons a creature that sides
   with it, engages what the avatar engages, and is relayed to every client as a cell actor.

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -442,13 +442,13 @@ export class WorldState {
   // the new cell has to find the claim made in the old one. The cell rides along (updated by
   // the holder's ActorCellChange) so a claim can be replayed to whoever next holds that cell
   // -- the peer restarts, and a fresh process has never heard who follows whom.
-  private readonly followedBy = new Map<string, { ref: ObjRef; cellKey: string; follow: number }>();
+  private readonly followedBy = new Map<string, { ref: ObjRef; cellKey: string; follow: number; escort?: Record<string, number> }>();
   private replayFollows(holderId: number, cellKey: string): void {
     const holder = this.roster.get(holderId);
     if (!holder) return;
     for (const f of this.followedBy.values()) {
       if (f.cellKey !== cellKey) continue;
-      holder.peer.sendEvent('ActorAI', { ...objRefToJs(f.ref), cellKey, epoch: 0, follow: f.follow });
+      holder.peer.sendEvent('ActorAI', { ...objRefToJs(f.ref), cellKey, epoch: 0, follow: f.follow, ...(f.escort ? { escort: f.escort } : {}) });
     }
   }
   private followClaim(player: Player, body: LTable): void {
@@ -464,11 +464,25 @@ export class WorldState {
       log('warn', 'actor.dropped', { from: player.name, name: 'ActorAI', cellKey, why: 'follow claim from afar' });
       return;
     }
+    // An escort is a follow with a destination: four finite numbers, or nothing.
+    const rawEscort = body.get('escort');
+    let escort: Record<string, number> | undefined;
+    if (rawEscort !== undefined) {
+      const t = rawEscort instanceof Map ? rawEscort as LTable : undefined;
+      const x = t ? finite(t.get('x')) : undefined, y = t ? finite(t.get('y')) : undefined;
+      const z = t ? finite(t.get('z')) : undefined, duration = t ? finite(t.get('duration')) : undefined;
+      if (x === undefined || y === undefined || z === undefined || duration === undefined
+        || Math.abs(x) > MAX_ABS_COORD || Math.abs(y) > MAX_ABS_COORD || Math.abs(z) > MAX_ABS_COORD || duration < 0) {
+        this.invalid(player, 'ActorAI');
+        return;
+      }
+      escort = { x, y, z, duration };
+    }
     if (follow === undefined) {
       if (this.followedBy.get(ref.key)?.follow !== player.id) return; // not yours to dismiss
       this.followedBy.delete(ref.key);
     } else {
-      this.followedBy.set(ref.key, { ref, cellKey, follow });
+      this.followedBy.set(ref.key, { ref, cellKey, follow, ...(escort ? { escort } : {}) });
     }
     this.relayCellExcept(cellKey, player.id, 'ActorAI', { ...lToJs(body) as Record<string, JsLike> });
   }

--- a/server/test/actor.test.ts
+++ b/server/test/actor.test.ts
@@ -155,6 +155,17 @@ test('actor authority and relay end to end', async (t) => {
     assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0,
       'a non-holder made an NPC follow somebody else and the server relayed it');
 
+    // An escort is a follow with a destination; a destination that is not four finite numbers
+    // is refused as a whole message.
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF, follow: bId, escort: { x: 100, y: 200, z: 3, duration: 0 } });
+    const esc = await a.waitEvent('ActorAI');
+    assert.deepEqual((esc.value as { escort?: unknown }).escort, { x: 100, y: 200, z: 3, duration: 0 }, 'the destination reaches the holder');
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { cellKey: '0,0', epoch: 0, ref: ACTOR_REF, follow: bId, escort: { x: 'far' } });
+    await fence('escortfence');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0, 'a malformed escort was relayed');
+
     // Only the player being followed may dismiss.
     const d = await TestClient.connect(server.port);
     await d.joinAsNew('Dana');


### PR DESCRIPTION
An `AIEscort player` from a dialogue result lands on the recruiting client, which never holds the cell; `companion.lua` reported Follow only, so escorts never reached the peer and every escort quest silently did not happen. Escort is now reported with its destination, validated on the claim, replayed to a new holder, and started on the peer against the avatar. Test added; tsc clean; Lua runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)