### PR TITLE
The guest's murder hunted the host, and the guest walked

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1193,6 +1193,13 @@ local function start()
             if p and p.obj and p.obj:isValid() then return p.obj end
             return nil
         end,
+        allAvatarsFn = function()
+            local out = {}
+            for _, p in pairs(puppets) do
+                if p.obj and p.obj:isValid() then out[#out + 1] = p.obj end
+            end
+            return out
+        end,
     })
     -- M7 world state (see scripts/mp/world.lua): clock, region/weather authority, custom
     -- records, cell resets, map sharing, server-pushed GUI.

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -633,6 +633,17 @@ handlers.MP_CrimeUpdate = function(data)
     -- engine's own bounty field is player-only -- hence the MP registry (mwmp/puppets.hpp),
     -- which is what the generalised crime pursuit reads.
     if mp.isSystem and mp.isSystem() then
+        -- SHARED CRIME IS ONE RECORD FOR THE PARTY: every client applies it to its own
+        -- player, so every avatar here has to carry it too, or the peer's guards hunt only
+        -- the one who did it while the clients believe everyone is wanted.
+        if data.shared and deps.allAvatarsFn then
+            local n = 0
+            for _, obj in pairs(deps.allAvatarsFn()) do
+                if obj and obj:isValid() and mp.setAvatarBounty then mp.setAvatarBounty(obj, level); n = n + 1 end
+            end
+            print(string.format('[mp] peer CrimeUpdate shared level=%d avatars=%d', level, n))
+            return
+        end
         local obj = (data.byId ~= nil and deps.avatarObjFn) and deps.avatarObjFn(data.byId) or nil
         print(string.format('[mp] peer CrimeUpdate byId=%s level=%d avatar=%s',
             tostring(data.byId), level, obj and 'yes' or 'NO'))

--- a/server/src/core/players.ts
+++ b/server/src/core/players.ts
@@ -90,6 +90,13 @@ export interface Player {
   // dead-avatar bar reports (hp 0) are ignored so the respawned player is not re-killed
   // while the avatar body is being replaced on the peer.
   resurrectedAt?: number;
+  // THE BOUNTY THE WORLD HOLDS THIS PLAYER TO, live. Not doc.bounty: with [sharing] crime the
+  // party has ONE criminal record (shared.bounty), and a guest's crime is persisted on the
+  // campaign they are visiting (quests.ts journalTarget), so the guest's own doc says 0 while
+  // the owner's says the guest's number. Seeding avatars from the doc hunted the host for the
+  // guest's murder and let the guest walk. Set on join from the world's view, updated on
+  // every CrimeUpdate, and what AvatarState carries.
+  bounty?: number;
   // Sliding-window budget for CLIENT-asserted restoration while the peer owns this player's
   // bars (potions, rest, self-heal -- all still client-side until the intent tier). Without a
   // bound, "a raise is a restoration" is an immortality exploit: a modified client claims full

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -404,7 +404,7 @@ function handleInventory(ctx: StateCtx, player: Player, body: LTable): boolean {
     // right damage. Same AvatarState the join sends; applyAvatarDoc reconciles shortfall,
     // surplus and states without duplicating what the body already holds.
     const worldPeer = ctx.worldPeer();
-    if (worldPeer) worldPeer.peer.sendEvent('AvatarState', avatarStateBody(player.id, doc));
+    if (worldPeer) worldPeer.peer.sendEvent('AvatarState', avatarStateBody(player.id, doc, player.bounty));
   });
   // The snapshot now accounts for everything credited since the last one, so the credit is
   // spent. Clearing here (rather than expiring on a timer) is what keeps the ledger from
@@ -636,7 +636,7 @@ export function handleStateEvent(ctx: StateCtx, player: Player, name: string, va
   if (ok && (name === 'PlayerAttributes' || name === 'PlayerSkills' || name === 'PlayerLevel')) {
     const worldPeer = ctx.worldPeer();
     const doc = ctx.store.getCached(player.charId);
-    if (worldPeer && doc) worldPeer.peer.sendEvent('AvatarState', avatarStateBody(player.id, doc));
+    if (worldPeer && doc) worldPeer.peer.sendEvent('AvatarState', avatarStateBody(player.id, doc, player.bounty));
   }
   return true;
 }
@@ -655,7 +655,7 @@ export function syncStateOnJoin(ctx: StateCtx, joiner: Player): void {
     if (doc?.equipment) joiner.peer.sendEvent('PlayerEquipment', { id: other.id, slots: equipmentToL(doc.equipment) });
     // Phase 2b: a JOINING PEER gets the whole character of everyone already here.
     if (joiner.system === true && !other.system && doc) {
-      joiner.peer.sendEvent('AvatarState', avatarStateBody(other.id, doc));
+      joiner.peer.sendEvent('AvatarState', avatarStateBody(other.id, doc, other.bounty));
     }
   }
   const own = ctx.store.getCached(joiner.charId);
@@ -666,7 +666,7 @@ export function syncStateOnJoin(ctx: StateCtx, joiner: Player): void {
     if (own.equipment) other.peer.sendEvent('PlayerEquipment', { id: joiner.id, slots: equipmentToL(own.equipment) });
     // Phase 2b: every PEER gets the whole character of a joining player.
     if (other.system === true && joiner.system !== true) {
-      other.peer.sendEvent('AvatarState', avatarStateBody(joiner.id, own));
+      other.peer.sendEvent('AvatarState', avatarStateBody(joiner.id, own, joiner.bounty));
     }
   }
 }
@@ -688,7 +688,7 @@ export function pushAvatarsToPeer(ctx: StateCtx, peer: Player): void {
   for (const other of ctx.roster.inWorld()) {
     if (other.system === true) continue;
     const doc = ctx.store.getCached(other.charId);
-    if (doc) peer.peer.sendEvent('AvatarState', avatarStateBody(other.id, doc));
+    if (doc) peer.peer.sendEvent('AvatarState', avatarStateBody(other.id, doc, other.bounty));
   }
 }
 
@@ -699,7 +699,8 @@ export function pushAvatarsToPeer(ctx: StateCtx, peer: Player): void {
 // shape (persist/playerstore.ts) is already exactly the right payload; this only sends it.
 // Incremental freshness rides the existing Player* identity relays, which peers receive
 // like any client; this is the join-time snapshot that must precede the avatar acting.
-export function avatarStateBody(id: number, doc: PlayerDoc): JsLike {
+export function avatarStateBody(id: number, doc: PlayerDoc, liveBounty?: number): JsLike {
+  const bounty = liveBounty ?? doc.bounty;
   return {
     id,
     ...(doc.stats ? { stats: doc.stats } : {}),
@@ -707,6 +708,6 @@ export function avatarStateBody(id: number, doc: PlayerDoc): JsLike {
     ...(doc.inventory ? { inventory: doc.inventory } : {}),
     ...(doc.itemStates ? { itemStates: doc.itemStates } : {}),
     ...(doc.factions ? { factions: doc.factions } : {}),
-    ...(doc.bounty !== undefined ? { bounty: doc.bounty } : {}),
+    ...(bounty !== undefined ? { bounty } : {}),
   } as unknown as JsLike;
 }

--- a/server/src/core/quests.ts
+++ b/server/src/core/quests.ts
@@ -245,7 +245,19 @@ export class Quests {
 
   // Full journal state for a joining client: the shared map, or their own in individual
   // mode. Always sent (an empty map is a valid, meaningful answer).
+  // The bounty this world holds the player to, at join (players.ts `bounty` says why it is
+  // not the doc's): the party's one record when crime is shared, else the campaign's.
+  seedBounty(player: Player): void {
+    if (this.ctx.isShared('crime')) {
+      player.bounty = this.ctx.cells.sharedQuest().bounty ?? 0;
+      return;
+    }
+    const target = this.ctx.journalTarget(player) ?? player.charId;
+    player.bounty = this.ctx.players.getCached(target)?.bounty ?? 0;
+  }
+
   sendJournalSync(player: Player): void {
+    this.seedBounty(player);
     if (this.ctx.isShared('journal')) {
       const shared = this.ctx.cells.sharedQuest();
       // Seed a FRESH instance from the owner's campaign. Their world's cell store starts
@@ -484,14 +496,23 @@ export class Quests {
     } else {
       log('info', 'quest.standing_not_persisted', { player: player.name, bounty });
     }
-    if (!this.ctx.isShared('crime')) return; // personal bounty
+    player.bounty = bounty;
+    if (!this.ctx.isShared('crime')) {
+      // Personal: nobody else's number moves, but the PEER still has to hunt this avatar.
+      this.ctx.worldPeer?.()?.peer.sendEvent('CrimeUpdate', { bounty, byId: player.id, ...(typeof kind === 'string' ? { kind } : {}) });
+      return;
+    }
     const shared = this.ctx.cells.sharedQuest();
     shared.bounty = bounty;
     this.ctx.cells.saveShared();
+    // ONE record for the party: every avatar is now wanted for it, not just the one who did
+    // it -- the clients already apply it to every local player, so the peer must match.
+    for (const p of this.ctx.roster.inWorld()) if (!p.system) p.bounty = bounty;
     this.relayAll(player.id, 'CrimeUpdate', {
       bounty,
       ...(typeof kind === 'string' ? { kind } : {}),
       byId: player.id,
+      shared: true,
     });
   }
 

--- a/server/test/avatarstate.test.ts
+++ b/server/test/avatarstate.test.ts
@@ -89,3 +89,33 @@ test('a player joining after the peer is announced to it; a CLIENT never sees Av
   const leaked = b.inbox.events.some((e) => e.name === 'AvatarState');
   assert.equal(leaked, false, "another player's full inventory reached a client");
 });
+
+// THE BOUNTY THE PEER HUNTS IS THE WORLD'S, NOT THE DOC'S. With shared crime the party has one
+// record: every client sets it on its own player, so every avatar must carry it too -- and it
+// must survive the next AvatarState refresh, which used to re-seed each avatar from its own doc
+// (0 for everyone but the campaign it was persisted on).
+test('a shared bounty reaches every avatar and survives an AvatarState refresh', async (t) => {
+  const { server, a } = await bootWithCharacter(t);
+  const b = await TestClient.connect(server.port);
+  t.after(() => b.close());
+  const wb = await b.joinAsNew('Bystander');
+  b.playerId = wb['playerId'] as number;
+  await b.waitEvent('PlayerList');
+  b.sendEvent('PlayerLevel', { level: 2 }); // a fresh player has no doc; give the bystander one
+  await new Promise((r) => setTimeout(r, 300));
+  const peer = await TestClient.simPeer(server.port, PEER_PASS);
+  t.after(() => peer.close());
+  await peer.waitEvent('AvatarState', (v) => (v as { id?: number })?.id === b.playerId, 8000);
+
+  peer.inbox.events.length = 0;
+  a.sendEvent('CrimeUpdate', { bounty: 500, kind: 'murder' });
+  const crime = await peer.waitEvent('CrimeUpdate');
+  assert.equal((crime.value as { shared?: boolean }).shared, true, 'the peer is told the record is shared');
+
+  // A refresh of the BYSTANDER's avatar (any inventory change) must carry the party's bounty.
+  b.sendEvent('PlayerInventory', { items: [{ id: 'gold_001', n: 5 }] });
+  const st = await peer.waitEvent('AvatarState',
+    (v) => (v as { id?: number })?.id === b.playerId && (v as { inventory?: unknown[] }).inventory !== undefined);
+  assert.equal((st.value as { bounty?: number }).bounty, 500,
+    "the bystander's avatar was re-seeded from their own doc and stopped being wanted");
+});

--- a/server/test/quests.test.ts
+++ b/server/test/quests.test.ts
@@ -145,7 +145,7 @@ test('shared factions and crime relay', async (t) => {
 
   await t.test('crime update relays with the reporter id', async () => {
     a.sendEvent('CrimeUpdate', { bounty: 40, kind: 'theft' });
-    assert.deepEqual((await b.waitEvent('CrimeUpdate')).value, { bounty: 40, kind: 'theft', byId: aId });
+    assert.deepEqual((await b.waitEvent('CrimeUpdate')).value, { bounty: 40, kind: 'theft', byId: aId, shared: true });
     a.sendEvent('CrimeUpdate', { bounty: -5 });
     await fence(a, b);
     assert.equal(b.inbox.events.filter((e) => e.name === 'CrimeUpdate').length, 0);


### PR DESCRIPTION
The peer seeded avatar bounties from each character's doc, but a guest's crime is persisted on the campaign (the owner's doc) and shared crime is one record for the party — so the host got hunted and the criminal's avatar was cleared on its next refresh. The server now tracks the live bounty per session and AvatarState carries that; shared crime reaches every avatar, personal crime still reaches the one. Persistence unchanged. Test added; tsc clean; Lua runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)