### PR TITLE
No wanted player was ever arrested, and assault and murder were never crimes

### DIFF
--- a/openmw/apps/openmw/mwmechanics/aipursue.cpp
+++ b/openmw/apps/openmw/mwmechanics/aipursue.cpp
@@ -1,5 +1,7 @@
 #include "aipursue.hpp"
 
+#include "../mwmp/puppets.hpp"
+
 #include <components/esm3/aisequence.hpp>
 
 #include "../mwbase/environment.hpp"
@@ -47,7 +49,15 @@ namespace MWMechanics
         if (target.getClass().getCreatureStats(target).isDead())
             return true;
 
-        if (target.getClass().getNpcStats(target).getBounty() <= 0)
+        // AN AVATAR'S BOUNTY LIVES IN THE MP REGISTRY, not on its NpcStats (which is 0 for
+        // every NPC). Reading NpcStats here ended the pursuit on its first frame, and
+        // updateCrimePursuit stacked it again on the next -- the guard stood there restarting
+        // a chase it never ran, thousands of times a minute, and no wanted player was ever
+        // reached on a simulated world.
+        const ESM::RefNum targetRef = target.getCellRef().getRefNum();
+        const bool targetIsAvatar = MWMP::isAvatar(targetRef);
+        const int bounty = targetIsAvatar ? MWMP::avatarBounty(targetRef) : target.getClass().getNpcStats(target).getBounty();
+        if (bounty <= 0)
             return true;
 
         actor.getClass().getCreatureStats(actor).setDrawState(DrawState::Nothing);
@@ -67,6 +77,13 @@ namespace MWMechanics
         {
             if (!MWBase::Environment::get().getWorld()->getLOS(target, actor))
                 return false;
+            if (targetIsAvatar)
+            {
+                // The owner is on another machine: the peer's scripts forward this and THEIR
+                // client opens the dialogue with its copy of this guard (mwmp/puppets.hpp).
+                MWMP::recordArrest(targetRef, actor.getCellRef().getRefNum());
+                return true;
+            }
             MWBase::Environment::get().getWindowManager()->pushGuiMode(
                 MWGui::GM_Dialogue, actor); // Arrest player when reached
             return true;

--- a/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1154,8 +1154,11 @@ namespace MWMechanics
     {
         // NOTE: victim may be empty
 
-        // Only player can commit crime
-        if (player != getPlayer())
+        // Only player can commit crime -- and on the sim peer every connected player is an
+        // AVATAR, not the dummy getPlayer(). Without this, assault and murder by a player on a
+        // simulated world were never crimes: the client cancels its own swing (the peer's job),
+        // and the peer's swing came from a body this gate did not recognise.
+        if (player != getPlayer() && !MWMP::isAvatar(player.getCellRef().getRefNum()))
             return false;
 
         if (type == OT_Assault)
@@ -1480,6 +1483,19 @@ namespace MWMechanics
 
         if (reported)
         {
+            const ESM::RefNum offender = player.getCellRef().getRefNum();
+            if (MWMP::isAvatar(offender))
+            {
+                // The bounty belongs to the owner's client; the peer records the increment for
+                // the scripts to forward, bumps the registry so the pursuit stacked above runs,
+                // and does none of the faction bookkeeping below -- that follows on the owner's
+                // machine from the CrimeUpdate their own engine produces.
+                const char* kind = type == OT_Theft ? "theft" : type == OT_Assault ? "assault"
+                    : type == OT_Murder ? "murder" : type == OT_Pickpocket ? "pickpocket"
+                    : type == OT_Trespassing ? "trespass" : "sleeping";
+                MWMP::recordCrime(offender, bounty, kind);
+                return reported;
+            }
             player.getClass().getNpcStats(player).setBounty(
                 std::max(0, player.getClass().getNpcStats(player).getBounty() + bounty));
 
@@ -1599,10 +1615,13 @@ namespace MWMechanics
 
         const MWMechanics::NpcStats& victimStats = victim.getClass().getNpcStats(victim);
         const MWWorld::Ptr& player = getPlayer();
-        bool canCommit = attacker == player && canCommitCrimeAgainst(victim, attacker);
+        // An avatar's kill is a player's kill (see commitCrime). The crime is committed AS the
+        // avatar so the bounty lands on its owner, not on the peer's dummy.
+        const bool attackerIsAvatar = MWMP::isAvatar(attacker.getCellRef().getRefNum());
+        bool canCommit = (attacker == player || attackerIsAvatar) && canCommitCrimeAgainst(victim, attacker);
 
         // For now we report only about crimes of player and player's followers
-        if (attacker != player)
+        if (attacker != player && !attackerIsAvatar)
         {
             std::set<MWWorld::Ptr> playerFollowers;
             getActorsSidingWith(player, playerFollowers);
@@ -1616,7 +1635,7 @@ namespace MWMechanics
         // Simple check for who attacked first: if the player attacked first, a crimeId should be set
         // Doesn't handle possible edge case where no one reported the assault, but in such a case,
         // for bystanders it is not possible to tell who attacked first, anyway.
-        commitCrime(player, victim, MWBase::MechanicsManager::OT_Murder);
+        commitCrime(attackerIsAvatar ? attacker : player, victim, MWBase::MechanicsManager::OT_Murder);
     }
 
     bool MechanicsManager::awarenessCheck(const MWWorld::Ptr& ptr, const MWWorld::Ptr& observer, bool useCache)

--- a/openmw/apps/openmw/mwmp/luabindings.cpp
+++ b/openmw/apps/openmw/mwmp/luabindings.cpp
@@ -248,6 +248,21 @@ namespace MWMP
                 out[i++] = MWLua::GObject(guard);
             return out;
         };
+        // Crimes an avatar committed here since the last call: {bounty=<increment>, kind=<string>}.
+        api["takeCrimes"] = [](sol::this_state state, const sol::object& obj) {
+            sol::table out(state, sol::create);
+            if (!obj.is<MWLua::Object>())
+                return out;
+            int i = 1;
+            for (const Crime& c : takeCrimesFor(obj.as<MWLua::Object>().id()))
+            {
+                sol::table e(state, sol::create);
+                e["bounty"] = c.mBounty;
+                e["kind"] = c.mKind;
+                out[i++] = e;
+            }
+            return out;
+        };
         api["isEnabled"] = []() { return std::getenv("OPENMW_MP_URL") != nullptr; };
         api["getUrl"] = []() { return getEnvString("OPENMW_MP_URL"); };
         api["getName"] = []() { return getEnvString("OPENMW_MP_NAME"); };

--- a/openmw/apps/openmw/mwmp/luabindings.cpp
+++ b/openmw/apps/openmw/mwmp/luabindings.cpp
@@ -236,6 +236,18 @@ namespace MWMP
             }
             return out;
         };
+        // The guards that reached a wanted avatar since the last call (AiPursue on the peer
+        // records instead of opening a dialogue nobody is there to see). Global context only:
+        // the caller is global.lua's avatar tick, and the objects come back as GObjects.
+        api["takeArrests"] = [](sol::this_state state, const sol::object& obj) {
+            sol::table out(state, sol::create);
+            if (!obj.is<MWLua::Object>())
+                return out;
+            int i = 1;
+            for (const ESM::RefNum guard : takeArrestsFor(obj.as<MWLua::Object>().id()))
+                out[i++] = MWLua::GObject(guard);
+            return out;
+        };
         api["isEnabled"] = []() { return std::getenv("OPENMW_MP_URL") != nullptr; };
         api["getUrl"] = []() { return getEnvString("OPENMW_MP_URL"); };
         api["getName"] = []() { return getEnvString("OPENMW_MP_NAME"); };

--- a/openmw/apps/openmw/mwmp/puppets.cpp
+++ b/openmw/apps/openmw/mwmp/puppets.cpp
@@ -1,5 +1,8 @@
 #include "puppets.hpp"
 
+#include <chrono>
+#include <map>
+
 #include <components/debug/debuglog.hpp>
 
 #include <unordered_map>
@@ -114,6 +117,57 @@ namespace MWMP
         if (pending().size() >= sMaxPending)
             return;
         pending().push_back(hit);
+    }
+
+    namespace
+    {
+        struct Arrest
+        {
+            ESM::RefNum mAvatar;
+            ESM::RefNum mGuard;
+        };
+        std::vector<Arrest>& arrests()
+        {
+            static std::vector<Arrest> v;
+            return v;
+        }
+        std::map<ESM::RefNum, std::chrono::steady_clock::time_point>& lastArrestAt()
+        {
+            static std::map<ESM::RefNum, std::chrono::steady_clock::time_point> m;
+            return m;
+        }
+        constexpr auto sArrestCooldown = std::chrono::seconds(8);
+    }
+
+    void recordArrest(ESM::RefNum avatar, ESM::RefNum guard)
+    {
+        const auto now = std::chrono::steady_clock::now();
+        auto& at = lastArrestAt();
+        const auto it = at.find(avatar);
+        if (it != at.end() && now - it->second < sArrestCooldown)
+            return;
+        at[avatar] = now;
+        if (arrests().size() >= sMaxPending)
+            return;
+        arrests().push_back({ avatar, guard });
+        Log(Debug::Info) << "[mp] guard " << guard.mIndex << " reached wanted avatar " << avatar.mIndex;
+    }
+
+    std::vector<ESM::RefNum> takeArrestsFor(ESM::RefNum avatar)
+    {
+        std::vector<ESM::RefNum> out;
+        auto& q = arrests();
+        for (auto it = q.begin(); it != q.end();)
+        {
+            if (it->mAvatar == avatar)
+            {
+                out.push_back(it->mGuard);
+                it = q.erase(it);
+            }
+            else
+                ++it;
+        }
+        return out;
     }
 
     std::vector<MagicHit> takeMagicHitsFor(ESM::RefNum target)

--- a/openmw/apps/openmw/mwmp/puppets.cpp
+++ b/openmw/apps/openmw/mwmp/puppets.cpp
@@ -1,5 +1,6 @@
 #include "puppets.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <map>
 
@@ -162,6 +163,45 @@ namespace MWMP
             if (it->mAvatar == avatar)
             {
                 out.push_back(it->mGuard);
+                it = q.erase(it);
+            }
+            else
+                ++it;
+        }
+        return out;
+    }
+
+    namespace
+    {
+        std::vector<Crime>& crimes()
+        {
+            static std::vector<Crime> v;
+            return v;
+        }
+    }
+
+    void recordCrime(ESM::RefNum avatar, int bounty, std::string kind)
+    {
+        auto& av = avatars();
+        const auto it = av.find(avatar);
+        if (it == av.end())
+            return;
+        it->second = std::max(0, it->second + bounty);
+        if (crimes().size() >= sMaxPending)
+            return;
+        crimes().push_back({ avatar, bounty, std::move(kind) });
+        Log(Debug::Info) << "[mp] avatar " << avatar.mIndex << " committed " << crimes().back().mKind << " bounty +" << bounty;
+    }
+
+    std::vector<Crime> takeCrimesFor(ESM::RefNum avatar)
+    {
+        std::vector<Crime> out;
+        auto& q = crimes();
+        for (auto it = q.begin(); it != q.end();)
+        {
+            if (it->mAvatar == avatar)
+            {
+                out.push_back(*it);
                 it = q.erase(it);
             }
             else

--- a/openmw/apps/openmw/mwmp/puppets.hpp
+++ b/openmw/apps/openmw/mwmp/puppets.hpp
@@ -95,6 +95,19 @@ namespace MWMP
 
     /** Drain the guards that reached ONE avatar since the last call. */
     std::vector<ESM::RefNum> takeArrestsFor(ESM::RefNum avatar);
+
+    /** A crime an avatar committed HERE and somebody reported (reportCrime). The bounty is the
+     *  owner's, on their client; the peer cannot write it, so the increment is recorded for
+     *  the scripts to forward. The registry bounty is bumped at once so the pursuit that
+     *  reportCrime just stacked does not end on its first frame. */
+    struct Crime
+    {
+        ESM::RefNum mAvatar;
+        int mBounty; // the increment, not the total
+        std::string mKind; // theft | assault | murder | trespass | pickpocket | sleeping
+    };
+    void recordCrime(ESM::RefNum avatar, int bounty, std::string kind);
+    std::vector<Crime> takeCrimesFor(ESM::RefNum avatar);
 }
 
 #endif

--- a/openmw/apps/openmw/mwmp/puppets.hpp
+++ b/openmw/apps/openmw/mwmp/puppets.hpp
@@ -86,6 +86,15 @@ namespace MWMP
 
     /** Drain everything recorded for ONE actor since the last call. */
     std::vector<MagicHit> takeMagicHitsFor(ESM::RefNum target);
+
+    /** A guard REACHED a wanted avatar (AiPursue). On the local player this opens the arrest
+     *  dialogue; an avatar's owner is on another machine, so it is recorded here for the
+     *  peer's scripts to forward. Rate-limited per avatar: the pursuit package re-stacks
+     *  every frame while the bounty stands, and the owner needs one prompt, not sixty. */
+    void recordArrest(ESM::RefNum avatar, ESM::RefNum guard);
+
+    /** Drain the guards that reached ONE avatar since the last call. */
+    std::vector<ESM::RefNum> takeArrestsFor(ESM::RefNum avatar);
 }
 
 #endif

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -730,6 +730,27 @@ local function avatarItemStatesTick(now)
     if #entries > 0 then mp.sendEvent('AvatarItemStatesBatch', { entries = entries }) end
 end
 
+-- ARREST. A guard that reaches a wanted avatar on the peer cannot open a dialogue nobody is
+-- there to see; the engine records the reach (mwmp/puppets.hpp recordArrest) and this hands
+-- it to the server for the owner's client, which opens the dialogue with ITS copy of the
+-- guard -- and vanilla's own greeting does the rest: pay the fine, go to jail, or resist.
+local function avatarArrestTick()
+    if not (mp.isSystem and mp.isSystem()) or not mp.takeArrests then return end
+    for id, p in pairs(puppets) do
+        if p.obj and p.obj:isValid() then
+            local ok, guards = pcall(mp.takeArrests, p.obj)
+            if ok and guards then
+                for _, guard in ipairs(guards) do
+                    local okv, valid = pcall(function() return guard:isValid() end)
+                    if okv and valid then
+                        mp.sendEvent('PlayerArrest', { id = id, guard = guard })
+                    end
+                end
+            end
+        end
+    end
+end
+
 -- Phase 4C safety: the peer resolves avatar-vs-avatar melee natively, so the server's
 -- allowPlayerHit veto never sees it. Tell every avatar whether pvp is on and which bodies
 -- are avatars, so avatar.lua can veto player-on-player damage while it is off. PvE is
@@ -1406,6 +1427,21 @@ local eventHandlers = {
         lastPose[data.id] = pose
         despawnPuppet(data.id)
         spawnPuppet(data.id, pose)
+    end,
+
+    -- A guard reached OUR avatar on the peer. Open the dialogue with our copy of that guard:
+    -- the local player carries the bounty (CrimeUpdate relay), so vanilla's greeting offers
+    -- the fine, the cell, or resisting -- exactly what it would have done had the guard
+    -- reached us here. Nothing to do if we cannot see the guard (another cell, not loaded):
+    -- the peer's guard keeps re-reaching every cooldown, so the prompt comes back.
+    MP_PlayerArrest = function(data)
+        if mp.isSystem and mp.isSystem() then return end
+        local guard = data and data.guard
+        local okv, valid = pcall(function() return guard and guard:isValid() end)
+        if not (okv and valid) then return end
+        local player = playerScript()
+        if not player then return end
+        toPlayer('MP_OpenDialogue', { target = guard })
     end,
 
     -- The owner's temporary active effects, mirrored onto the avatar (identity.lua snapActive
@@ -2580,6 +2616,7 @@ return {
                 end
                 avatarStatsTick(now) -- Phase 4A: peer reports avatar bars to the server
                 avatarItemStatesTick(now) -- Phase 4D: peer reports avatar wear/charge/soul
+                avatarArrestTick() -- a guard reached a wanted avatar: tell its owner
             end
         end,
     },

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -738,6 +738,16 @@ local function avatarArrestTick()
     if not (mp.isSystem and mp.isSystem()) or not mp.takeArrests then return end
     for id, p in pairs(puppets) do
         if p.obj and p.obj:isValid() then
+            -- Crimes the avatar committed on this engine (assault, murder: the peer's swing is
+            -- the one that lands). The bounty is the owner's; they get the increment.
+            if mp.takeCrimes then
+                local okc, crimes = pcall(mp.takeCrimes, p.obj)
+                if okc and crimes then
+                    for _, c in ipairs(crimes) do
+                        mp.sendEvent('PlayerCrime', { id = id, bounty = c.bounty, kind = c.kind })
+                    end
+                end
+            end
             local ok, guards = pcall(mp.takeArrests, p.obj)
             if ok and guards then
                 for _, guard in ipairs(guards) do
@@ -1434,6 +1444,21 @@ local eventHandlers = {
     -- the fine, the cell, or resisting -- exactly what it would have done had the guard
     -- reached us here. Nothing to do if we cannot see the guard (another cell, not loaded):
     -- the peer's guard keeps re-reaching every cooldown, so the prompt comes back.
+    -- Our avatar committed a crime on the peer and somebody reported it. Raise our own
+    -- bounty by the increment; quests.lua's diff then sends the CrimeUpdate that every
+    -- other screen -- and the peer -- takes as the truth.
+    MP_PlayerCrime = function(data)
+        if mp.isSystem and mp.isSystem() then return end
+        if not data or type(data.bounty) ~= 'number' then return end
+        local player = playerScript()
+        if not player then return end
+        pcall(function()
+            local level = types.Player.getCrimeLevel(player) or 0
+            types.Player.setCrimeLevel(player, math.max(0, math.floor(level + data.bounty + 0.5)))
+        end)
+        notice(string.format('Your %s was reported. Bounty +%d.', tostring(data.kind or 'crime'), math.floor(data.bounty + 0.5)))
+    end,
+
     MP_PlayerArrest = function(data)
         if mp.isSystem and mp.isSystem() then return end
         local guard = data and data.guard

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -809,6 +809,14 @@ return {
             end)
             mp.set('selfItemStates', tostring(next(data.itemStates) ~= nil))
         end,
+        -- Arrest (global.lua MP_PlayerArrest): the guard that reached our avatar, resolved
+        -- to our copy of it. UI modes are player-script-only, hence the hop.
+        MP_OpenDialogue = function(data)
+            local target = data and data.target
+            local okv, valid = pcall(function() return target and target:isValid() end)
+            if not (okv and valid) then return end
+            pcall(function() I.UI.addMode('Dialogue', { target = target }) end)
+        end,
         MP_SelfStats = function(data)
             if not data or not data.hp then return end
             -- Scenario mirror: proves the PEER-authoritative bars actually flowed (a local

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -856,6 +856,15 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
+* **"Resist arrest" starts a fight nobody simulates.** The arrest dialogue now reaches the
+  wanted player (PlayerArrest, 2026-09-11), and pay/jail work because they act on the local
+  player and the bounty relays. Resisting runs `StartCombat player` on the GUARD -- on the
+  owner's client, where the guard is a puppet with AI off, so the fight is cancelled there and
+  never told to the peer; the peer's guard keeps re-reaching and the prompt returns every
+  cooldown. Same class as the dialogue-started AiTravel below: a package stacked on a puppet
+  by a dialogue result needs to travel to the holder. The bounty increase from resisting DOES
+  relay, so the player is at least more wanted, not less.
+
 * **Dialogue-started AiTravel never reaches the peer.** Follow and Escort now travel from
   the recruiting client (companion.lua -> ActorAI claim), but "AITravel x y z" from a
   dialogue result -- the guard who walks off to fetch someone, the NPC who leaves the room

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -48,7 +48,7 @@ import type { BanStore } from '../persist/banstore';
 import type { ResumeStore, ResumeTicket } from '../core/resume';
 import type { LoginTicketStore, SessionIndex } from '../auth/identities';
 import type { PlayerStore, PlayerDoc } from '../persist/playerstore';
-import { lserDecode, lserEncode, jsToL, LserError, type JsLike, type LValue } from '../proto/lser';
+import { lserDecode, lserEncode, jsToL, lToJs, LserError, type JsLike, type LValue } from '../proto/lser';
 import {
   parseSessionMessage,
   helloOk,
@@ -667,6 +667,23 @@ export class Connection implements Peer {
     if (name === 'AvatarItemStatesBatch') {
       // Phase 4D: the peer's avatar wear/charge/soul reports (system-only).
       handleAvatarItemStatesBatch(this.ctx.stateCtx, this.player, value);
+      return;
+    }
+    if (name === 'PlayerArrest') {
+      // A guard reached a wanted avatar on the peer; the owner's client opens the arrest
+      // dialogue with its copy of that guard. Only THE world peer may say so -- a client
+      // sending this would be forcing a dialogue onto somebody else's screen.
+      if (this.player.system !== true || this.player !== this.ctx.worldPeer()) {
+        log('warn', 'conn.arrest_forged', { from: this.player.name, account: this.player.accountKey });
+        return;
+      }
+      const body = value instanceof Map ? value : undefined;
+      const idv = body?.get('id');
+      const id = typeof idv === 'number' ? idv : undefined;
+      const guard = body?.get('guard');
+      const target = id !== undefined ? this.ctx.roster.get(id) : undefined;
+      if (!target || target.system === true || !target.inWorld || guard === undefined) return;
+      target.peer.sendEvent('PlayerArrest', { guard: lToJs(guard) as JsLike });
       return;
     }
     if (handleStateEvent(this.ctx.stateCtx, this.player, name, value)) return; // M2 family

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -669,6 +669,23 @@ export class Connection implements Peer {
       handleAvatarItemStatesBatch(this.ctx.stateCtx, this.player, value);
       return;
     }
+    if (name === 'PlayerCrime') {
+      // An avatar committed a crime on the peer (assault, murder). The bounty is the owner's:
+      // the increment goes to their client, whose own CrimeUpdate then carries the total.
+      // World peer only, same as PlayerArrest: a client cannot make somebody else wanted.
+      if (this.player.system !== true || this.player !== this.ctx.worldPeer()) {
+        log('warn', 'conn.crime_forged', { from: this.player.name, account: this.player.accountKey });
+        return;
+      }
+      const body = value instanceof Map ? value : undefined;
+      const idv = body?.get('id'); const bv = body?.get('bounty'); const kv = body?.get('kind');
+      const id = typeof idv === 'number' ? idv : undefined;
+      const bounty = typeof bv === 'number' && Number.isFinite(bv) && Math.abs(bv) <= 100_000 ? bv : undefined;
+      const target = id !== undefined ? this.ctx.roster.get(id) : undefined;
+      if (!target || target.system === true || !target.inWorld || bounty === undefined) return;
+      target.peer.sendEvent('PlayerCrime', { bounty, ...(typeof kv === 'string' ? { kind: kv.slice(0, 16) } : {}) });
+      return;
+    }
     if (name === 'PlayerArrest') {
       // A guard reached a wanted avatar on the peer; the owner's client opens the arrest
       // dialogue with its copy of that guard. Only THE world peer may say so -- a client

--- a/server/test/avatarstate.test.ts
+++ b/server/test/avatarstate.test.ts
@@ -135,14 +135,22 @@ test('a guard reaching an avatar on the peer reaches the owner as PlayerArrest; 
   const got = await a.waitEvent('PlayerArrest');
   assert.ok((got.value as { guard?: unknown }).guard !== undefined, 'the guard reaches the owner');
 
+  // ...and a crime the avatar committed on the peer reaches the owner as an increment.
+  peer.sendEvent('PlayerCrime', { id: a.playerId, bounty: 40, kind: 'assault' });
+  const crime = await a.waitEvent('PlayerCrime');
+  assert.deepEqual(crime.value, { bounty: 40, kind: 'assault' }, 'the increment and kind reach the owner');
+
   const b = await TestClient.connect(server.port);
   t.after(() => b.close());
   await b.joinAsNew('Forger');
   await b.waitEvent('PlayerList');
   a.inbox.events.length = 0;
   b.sendEvent('PlayerArrest', { id: a.playerId, guard: GUARD });
+  b.sendEvent('PlayerCrime', { id: a.playerId, bounty: 5000, kind: 'murder' });
   b.sendEvent('ChatSend', { text: 'arrestfence' });
   await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'arrestfence');
   assert.equal(a.inbox.events.filter((e) => e.name === 'PlayerArrest').length, 0,
     'a client forced an arrest dialogue onto another player');
+  assert.equal(a.inbox.events.filter((e) => e.name === 'PlayerCrime').length, 0,
+    'a client made another player wanted');
 });

--- a/server/test/avatarstate.test.ts
+++ b/server/test/avatarstate.test.ts
@@ -119,3 +119,30 @@ test('a shared bounty reaches every avatar and survives an AvatarState refresh',
   assert.equal((st.value as { bounty?: number }).bounty, 500,
     "the bystander's avatar was re-seeded from their own doc and stopped being wanted");
 });
+
+// ARREST. A guard that reaches a wanted avatar on the peer cannot open a dialogue there; the
+// peer reports it and the OWNER's client opens the dialogue with its copy of the guard. Only
+// the world peer may say so -- a client saying it would force a dialogue onto someone's screen.
+test('a guard reaching an avatar on the peer reaches the owner as PlayerArrest; a client cannot forge it', async (t) => {
+  const { server, a } = await bootWithCharacter(t);
+  const peer = await TestClient.simPeer(server.port, PEER_PASS);
+  t.after(() => peer.close());
+  await peer.waitEvent('AvatarState', (v) => (v as { id?: number })?.id === a.playerId, 8000);
+  const GUARD = { __refnum: { index: 77, contentFile: 0 } };
+
+  a.inbox.events.length = 0;
+  peer.sendEvent('PlayerArrest', { id: a.playerId, guard: GUARD });
+  const got = await a.waitEvent('PlayerArrest');
+  assert.ok((got.value as { guard?: unknown }).guard !== undefined, 'the guard reaches the owner');
+
+  const b = await TestClient.connect(server.port);
+  t.after(() => b.close());
+  await b.joinAsNew('Forger');
+  await b.waitEvent('PlayerList');
+  a.inbox.events.length = 0;
+  b.sendEvent('PlayerArrest', { id: a.playerId, guard: GUARD });
+  b.sendEvent('ChatSend', { text: 'arrestfence' });
+  await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'arrestfence');
+  assert.equal(a.inbox.events.filter((e) => e.name === 'PlayerArrest').length, 0,
+    'a client forced an arrest dialogue onto another player');
+});


### PR DESCRIPTION
Two engine gates on the peer said "player" and meant the dummy. **Arrest:** `AiPursue::execute` read the target's NpcStats bounty (0 for an avatar) so the chase ended on frame one forever ("13,444 log lines"); on reach it would have opened the dialogue on the headless peer. Now: registry bounty for avatars; the reach is recorded (rate-limited) → `PlayerArrest` → owner's client opens the dialogue with its copy of the guard; vanilla handles fine/jail/resist. **Crime:** `commitCrime`/`actorKilled` only knew `getPlayer()`, so assault and murder by a player were never reported on a simulated world. Now an avatar is an offender; the increment is recorded → `PlayerCrime` → owner's crime level rises → the existing CrimeUpdate diff makes it the total everywhere. Both relays are world-peer-only with forgery tests. tsc clean; Lua runner 90/90; native peer compiling before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)