### PR TITLE
The world talks back: persuasion, replayed encounters, greetings, disease and hostile effects, werewolves, taunts, resting mid-fight

### DIFF
--- a/openmw/apps/openmw/mwmechanics/actors.cpp
+++ b/openmw/apps/openmw/mwmechanics/actors.cpp
@@ -1713,6 +1713,17 @@ namespace MWMechanics
                                 playIdleDialogue(actor.getPtr());
                                 updateMovementSpeed(actor.getPtr());
                             }
+                            else if (isConscious(actor.getPtr())
+                                && MWMP::isPuppet(actor.getPtr().getCellRef().getRefNum()))
+                            {
+                                // A PUPPET IS STILL A PERSON TO TALK TO. On a client every NPC in
+                                // a held cell is a puppet with its AI off, and greetings and idle
+                                // chatter lived inside the AI block -- so nobody ever turned to a
+                                // player or said a word to them: a whole town of shop mannequins.
+                                // Motion stays the holder's; a greeting is a look and a voice line.
+                                updateGreetingState(actor.getPtr(), actor, mTimerUpdateHello > 0);
+                                playIdleDialogue(actor.getPtr());
+                            }
                         }
                     }
                     else if (aiActive && !isPlayer && isConscious(actor.getPtr())

--- a/openmw/apps/openmw/mwmechanics/spelleffects.cpp
+++ b/openmw/apps/openmw/mwmechanics/spelleffects.cpp
@@ -662,7 +662,14 @@ namespace MWMechanics
             {
                 if (!target.isInCell())
                     return ESM::ActiveEffect::Flag_Invalid;
-                effect.mArg = summonCreature(effect.mEffectId, target);
+                // Multiplayer: while a peer holds this cell the player's summon is spawned on
+                // the peer beside the avatar (the effect travels there); a local copy would be
+                // a second creature that fights nothing. The effect stays active with no
+                // creature of its own here, exactly as a failed summon does.
+                if (target == MWMechanics::getPlayer() && !MWMP::localSummonsEnabled())
+                    effect.mArg = ESM::RefNum();
+                else
+                    effect.mArg = summonCreature(effect.mEffectId, target);
             }
             else if (effect.mEffectId == ESM::MagicEffect::BoundGloves)
             {

--- a/openmw/apps/openmw/mwmechanics/spelleffects.cpp
+++ b/openmw/apps/openmw/mwmechanics/spelleffects.cpp
@@ -666,9 +666,13 @@ namespace MWMechanics
                 // the peer beside the avatar (the effect travels there); a local copy would be
                 // a second creature that fights nothing. The effect stays active with no
                 // creature of its own here, exactly as a failed summon does.
+#ifdef __EMSCRIPTEN__
+                // Client-only by construction: the native build is the sim peer, which is the
+                // holder and never suppresses its own summons.
                 if (target == MWMechanics::getPlayer() && !MWMP::localSummonsEnabled())
                     effect.mArg = ESM::RefNum();
                 else
+#endif
                     effect.mArg = summonCreature(effect.mEffectId, target);
             }
             else if (effect.mEffectId == ESM::MagicEffect::BoundGloves)

--- a/openmw/apps/openmw/mwmp/luabindings.cpp
+++ b/openmw/apps/openmw/mwmp/luabindings.cpp
@@ -263,6 +263,8 @@ namespace MWMP
             }
             return out;
         };
+        // Client: whether the player's own Summon effects spawn a creature HERE (see puppets.hpp).
+        api["setLocalSummons"] = [](bool enabled) { setLocalSummons(enabled); };
         api["isEnabled"] = []() { return std::getenv("OPENMW_MP_URL") != nullptr; };
         api["getUrl"] = []() { return getEnvString("OPENMW_MP_URL"); };
         api["getName"] = []() { return getEnvString("OPENMW_MP_NAME"); };

--- a/openmw/apps/openmw/mwmp/puppets.cpp
+++ b/openmw/apps/openmw/mwmp/puppets.cpp
@@ -210,6 +210,25 @@ namespace MWMP
         return out;
     }
 
+    namespace
+    {
+        bool& localSummons()
+        {
+            static bool v = true;
+            return v;
+        }
+    }
+
+    void setLocalSummons(bool enabled)
+    {
+        localSummons() = enabled;
+    }
+
+    bool localSummonsEnabled()
+    {
+        return localSummons();
+    }
+
     std::vector<MagicHit> takeMagicHitsFor(ESM::RefNum target)
     {
         std::vector<MagicHit> out;

--- a/openmw/apps/openmw/mwmp/puppets.hpp
+++ b/openmw/apps/openmw/mwmp/puppets.hpp
@@ -108,6 +108,14 @@ namespace MWMP
     };
     void recordCrime(ESM::RefNum avatar, int bounty, std::string kind);
     std::vector<Crime> takeCrimesFor(ESM::RefNum avatar);
+
+    /** CLIENT ONLY. While a peer simulates the cell the player stands in, the player's own
+     *  Summon effects must not spawn a creature here: the same effect reaches the avatar
+     *  (PlayerActiveSpells) and the peer's summon is the one that fights and is relayed. A
+     *  local copy is a ghost with its own AI whose blows on puppets are cancelled. Toggled by
+     *  scripts/mp (mp.setLocalSummons) from the cell's holder state; default on (singleplayer). */
+    void setLocalSummons(bool enabled);
+    bool localSummonsEnabled();
 }
 
 #endif

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -514,6 +514,21 @@ function actors.noteCombat(obj, target)
     })
 end
 
+-- SCRIPTED TRAVEL. "AITravel x y z" from a dialogue result stacks Travel on the talking
+-- player's puppet; the holder's copy never moves. The holder reports its own travel too (it
+-- is authoritative), a non-holder only right after talking to the NPC (worldstate.ts admits
+-- it from the dialogue-lock holder) -- and on an AI-off puppet the only way the active package
+-- changes IS a script, so there is nothing else this could be.
+function actors.noteTravel(obj, dest)
+    if not (obj and obj:isValid()) or type(dest) ~= 'table' or type(dest.x) ~= 'number' then return end
+    local cellKey = actors.cellKeyOfObj(obj)
+    if not cellKey then return end
+    mp.sendEvent('ActorAI', {
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj,
+        travel = { x = dest.x, y = dest.y or 0, z = dest.z or 0 },
+    })
+end
+
 local function aimAt(obj, target, escort)
     if type(escort) == 'table' and type(escort.x) == 'number' then
         pcall(function()
@@ -564,6 +579,15 @@ end
 actors.handlers.MP_ActorAI = function(data)
     local obj = data.ref and data.ref:isValid() and data.ref or nil
     if not obj then return end
+    if type(data.travel) == 'table' and type(data.travel.x) == 'number' then
+        -- A scripted destination. On a puppet (AI off) it is state only; on the holder the
+        -- actor walks there, which is the point.
+        pcall(function()
+            obj:sendEvent('StartAIPackage', { type = 'Travel',
+                destPosition = util.vector3(data.travel.x, data.travel.y or 0, data.travel.z or 0) })
+        end)
+        return
+    end
     if data.combat ~= nil then
         -- The holder says this actor is (or stopped) fighting a player. Stacked on the puppet
         -- with its AI off it never executes; it only makes the state readable. On MP_Detach

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -500,10 +500,17 @@ end
 function actors.noteCombat(obj, target)
     if not (obj and obj:isValid()) then return end
     local cellKey = actors.cellKeyOfObj(obj)
-    if not cellKey or not actors.isHolderOf(cellKey) then return end
+    if not cellKey then return end
     local foeId = deps.playerIdOf and deps.playerIdOf(target) or nil
+    if not actors.isHolderOf(cellKey) then
+        -- Not ours to say -- except "it now fights ME", the result of a taunt or of resisting
+        -- arrest, which happens on this client and nowhere else. The server admits it from the
+        -- player who was just talking to the NPC (worldstate.ts), and the holder starts the fight.
+        local own = deps.ownIdFn and deps.ownIdFn() or nil
+        if foeId == nil or foeId ~= own then return end
+    end
     mp.sendEvent('ActorAI', {
-        cellKey = cellKey, epoch = actors.epochOf(cellKey), ref = obj, combat = foeId or false,
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj, combat = foeId or false,
     })
 end
 

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -480,6 +480,19 @@ function actors.noteFollow(obj, target, escort)
     })
 end
 
+-- PERSUASION, the sending half. Called by quests.lua when a conversation ends and the NPC's
+-- disposition is not what it was when it began. The server admits it from the player who
+-- held that NPC's dialogue lock (worldstate.ts), so this is sent BEFORE the lock is released.
+function actors.noteDisposition(obj, disposition)
+    if not (obj and obj:isValid()) or type(disposition) ~= 'number' then return end
+    local cellKey = actors.cellKeyOfObj(obj)
+    if not cellKey then return end
+    mp.sendEvent('ActorDisposition', {
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj,
+        disposition = math.max(0, math.min(100, math.floor(disposition + 0.5))),
+    })
+end
+
 local function aimAt(obj, target, escort)
     if type(escort) == 'table' and type(escort.x) == 'number' then
         pcall(function()

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -493,6 +493,20 @@ function actors.noteDisposition(obj, disposition)
     })
 end
 
+-- COMBAT STATE, the sending half. Holder-only (the holder is where the fight is real): who
+-- this actor is fighting, when that is a player. Rides ActorAI with a `combat` field so the
+-- client's AI-off puppet can be put into the same state and vanilla's own checks -- rest
+-- refused while an enemy is on you, no greeting from someone swinging at you -- read true.
+function actors.noteCombat(obj, target)
+    if not (obj and obj:isValid()) then return end
+    local cellKey = actors.cellKeyOfObj(obj)
+    if not cellKey or not actors.isHolderOf(cellKey) then return end
+    local foeId = deps.playerIdOf and deps.playerIdOf(target) or nil
+    mp.sendEvent('ActorAI', {
+        cellKey = cellKey, epoch = actors.epochOf(cellKey), ref = obj, combat = foeId or false,
+    })
+end
+
 local function aimAt(obj, target, escort)
     if type(escort) == 'table' and type(escort.x) == 'number' then
         pcall(function()
@@ -543,6 +557,18 @@ end
 actors.handlers.MP_ActorAI = function(data)
     local obj = data.ref and data.ref:isValid() and data.ref or nil
     if not obj then return end
+    if data.combat ~= nil then
+        -- The holder says this actor is (or stopped) fighting a player. Stacked on the puppet
+        -- with its AI off it never executes; it only makes the state readable. On MP_Detach
+        -- the AI resumes with the fight it was actually in, which is right.
+        local foe = data.combat and deps.playerObjOf and deps.playerObjOf(data.combat) or nil
+        if foe then
+            pcall(function() obj:sendEvent('StartAIPackage', { type = 'Combat', target = foe }) end)
+        else
+            pcall(function() obj:sendEvent('RemoveAIPackages', 'Combat') end)
+        end
+        return
+    end
     local key = refKeyOf(obj)
     for _, list in pairs(followersOf) do list[key] = nil end
     if data.follow ~= nil then

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -26,6 +26,18 @@ local nextPoll = 0
 -- Starts nil, which is also "following nobody" -- so an ordinary NPC, which is almost all of
 -- them, never sends a single event in its life.
 local reportedId = nil
+-- ...and who we are fighting, if it is a player. The client's copy of us has its AI off and
+-- an empty combat state, so nothing there knew a fight was on: the player could open the rest
+-- dialog mid-bite. Reported on change like the follow, and relayed the same way (ActorAI).
+local reportedCombat = nil
+
+local function fightingPlayer()
+    local ok, pkg = pcall(function() return I.AI.getActivePackage() end)
+    if not (ok and pkg and pkg.type == 'Combat') then return nil end
+    local t = pkg.target
+    local okv, valid = pcall(function() return t and t:isValid() end)
+    return (okv and valid) and t or nil
+end
 
 local function playerAmong(packageType)
     -- getTargets rather than getActiveTarget: a follower that is momentarily fighting, or
@@ -62,6 +74,14 @@ return {
             local now = core.getRealTime()
             if now < nextPoll then return end
             nextPoll = now + POLL
+
+            -- Combat first: independent of following, and its own change key.
+            local foe = fightingPlayer()
+            local foeId = foe and foe.id or nil
+            if foeId ~= reportedCombat then
+                reportedCombat = foeId
+                core.sendGlobalEvent('mpActorCombat', { actor = self.object, target = foe })
+            end
 
             local target, escort = followedPlayer()
             -- Compared by ID, not by object: two reads of the same actor are different Lua

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -31,6 +31,17 @@ local reportedId = nil
 -- dialog mid-bite. Reported on change like the follow, and relayed the same way (ActorAI).
 local reportedCombat = nil
 
+-- ...and where we are travelling, if a script sent us. On a puppet the AI never runs, so the
+-- top of the package stack is static -- the only thing that can change it is a dialogue result
+-- ("AITravel x y z" on Goodbye), which is exactly the case that never reached the holder.
+local reportedTravel = nil
+local function travelDest()
+    local ok, pkg = pcall(function() return I.AI.getActivePackage() end)
+    if not (ok and pkg and pkg.type == 'Travel' and pkg.destPosition) then return nil end
+    local d = pkg.destPosition
+    return { x = d.x, y = d.y, z = d.z }
+end
+
 local function fightingPlayer()
     local ok, pkg = pcall(function() return I.AI.getActivePackage() end)
     if not (ok and pkg and pkg.type == 'Combat') then return nil end
@@ -81,6 +92,13 @@ return {
             if foeId ~= reportedCombat then
                 reportedCombat = foeId
                 core.sendGlobalEvent('mpActorCombat', { actor = self.object, target = foe })
+            end
+
+            local dest = travelDest()
+            local destKey = dest and string.format('%.0f,%.0f,%.0f', dest.x, dest.y, dest.z) or nil
+            if destKey ~= reportedTravel then
+                reportedTravel = destKey
+                if dest then core.sendGlobalEvent('mpActorTravel', { actor = self.object, dest = dest }) end
             end
 
             local target, escort = followedPlayer()

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -809,6 +809,20 @@ local function avatarEffectsTick(now)
     if #entries > 0 then mp.sendEvent('AvatarEffectsBatch', { entries = entries }) end
 end
 
+-- SUMMONS SPAWN WHERE THEY FIGHT. Our Summon effect reaches the avatar, and the peer's
+-- creature is the one that engages and is relayed to everyone -- so while a holder simulates
+-- our cell the engine must not spawn a local copy too (mwmp/puppets.hpp setLocalSummons).
+-- Re-evaluated as the holder comes and goes; degraded mode (no peer) keeps local summons.
+local localSummonsOn = true
+local function localSummonsTick()
+    if (mp.isSystem and mp.isSystem()) or not mp.setLocalSummons then return end
+    local want = not actors.hasHolder(ownCellKeyCache)
+    if want ~= localSummonsOn then
+        localSummonsOn = want
+        pcall(mp.setLocalSummons, want)
+    end
+end
+
 -- ARREST. A guard that reaches a wanted avatar on the peer cannot open a dialogue nobody is
 -- there to see; the engine records the reach (mwmp/puppets.hpp recordArrest) and this hands
 -- it to the server for the owner's client, which opens the dialogue with ITS copy of the
@@ -2779,6 +2793,7 @@ return {
                 objects.tick(now)
                 actors.tick(now)
                 quests.tick(now)
+                localSummonsTick() -- summons spawn on the peer while it holds our cell
                 worldmp.tick(now)
                 mirrorDoor(now)
                 avatarStreamTick(now) -- Phase 3: peer streams authoritative avatar poses

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -730,6 +730,85 @@ local function avatarItemStatesTick(now)
     if #entries > 0 then mp.sendEvent('AvatarItemStatesBatch', { entries = entries }) end
 end
 
+-- WHAT THE WORLD DID TO THE AVATAR, back to its owner. The owner->avatar direction carries
+-- what the player cast or drank (MP_AvatarActiveSpells); this is the other half. A diseased
+-- rat's bite lands on the avatar (the peer resolves the hit) and puts a disease in the
+-- avatar's SPELL LIST; a hostile caster's Paralyze, Burden or Silence lands on the avatar as
+-- an ACTIVE EFFECT. Neither reached the player's own engine: the player kept walking while
+-- their body stood paralysed on the peer, and never caught a disease in their life.
+--   * spells: anything in the avatar's list that the doc did not put there, reported once;
+--   * effects: temporary, not from equipment, and not a record the owner sent us -- diffed by
+--     instance so a second Burden is a second report and an expiry is a removal.
+local ownerActive = {} -- id -> { localRecordId -> count } effects the OWNER applied here
+local avatarEffectsAt = 0
+local AVATAR_EFFECTS_EVERY = 1.0
+local avatarSpellsReported = {} -- id -> { localSpellId -> true }
+local avatarEffectsReported = {} -- id -> { activeSpellId -> localRecordId }
+
+local function avatarEffectsTick(now)
+    if not (mp.isSystem and mp.isSystem()) then return end
+    if now - avatarEffectsAt < AVATAR_EFFECTS_EVERY then return end
+    avatarEffectsAt = now
+    local entries = {}
+    for id, p in pairs(puppets) do
+        if p.obj and p.obj:isValid() then
+            local entry = { id = id }
+            local any = false
+            -- Spells the world gave the avatar (disease, blight, a curse).
+            local docSpells = {}
+            for _, sid in ipairs((avatarDocs[id] and avatarDocs[id].spells) or {}) do
+                docSpells[worldmp.toLocal(sid)] = true
+            end
+            avatarSpellsReported[id] = avatarSpellsReported[id] or {}
+            local okS = pcall(function()
+                for _, spell in pairs(types.Actor.spells(p.obj)) do
+                    if not docSpells[spell.id] and not avatarSpellsReported[id][spell.id] then
+                        avatarSpellsReported[id][spell.id] = true
+                        entry.spellsAdd = entry.spellsAdd or {}
+                        entry.spellsAdd[#entry.spellsAdd + 1] = worldmp.toNet(spell.id)
+                        any = true
+                    end
+                end
+            end)
+            -- Effects the world put on the avatar.
+            local known = ownerActive[id] or {}
+            local seen = {}
+            local reported = avatarEffectsReported[id] or {}
+            local okE = pcall(function()
+                for _, sp in pairs(types.Actor.activeSpells(p.obj)) do
+                    if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil
+                        and not known[sp.id] then
+                        seen[sp.activeSpellId] = sp.id
+                        if not reported[sp.activeSpellId] then
+                            local idx = {}
+                            for _, e in ipairs(sp.effects or {}) do
+                                if e.index ~= nil then idx[#idx + 1] = e.index end
+                            end
+                            if #idx > 0 then
+                                entry.effectsAdd = entry.effectsAdd or {}
+                                entry.effectsAdd[#entry.effectsAdd + 1] = { id = worldmp.toNet(sp.id), effects = idx }
+                                any = true
+                            end
+                        end
+                    end
+                end
+            end)
+            if okE then
+                for aid, rid in pairs(reported) do
+                    if not seen[aid] then
+                        entry.effectsRemove = entry.effectsRemove or {}
+                        entry.effectsRemove[#entry.effectsRemove + 1] = { id = worldmp.toNet(rid) }
+                        any = true
+                    end
+                end
+                avatarEffectsReported[id] = seen
+            end
+            if (okS or okE) and any then entries[#entries + 1] = entry end
+        end
+    end
+    if #entries > 0 then mp.sendEvent('AvatarEffectsBatch', { entries = entries }) end
+end
+
 -- ARREST. A guard that reaches a wanted avatar on the peer cannot open a dialogue nobody is
 -- there to see; the engine records the reach (mwmp/puppets.hpp recordArrest) and this hands
 -- it to the server for the owner's client, which opens the dialogue with ITS copy of the
@@ -847,6 +926,9 @@ local function despawnPuppet(id)
     avatarUsing[id] = nil
     avatarItemStatesLast[id] = nil
     avatarItemStatesSentAt[id] = nil
+    ownerActive[id] = nil
+    avatarSpellsReported[id] = nil
+    avatarEffectsReported[id] = nil
     -- Guarded, and deliberately AFTER the bookkeeping above: remove() throws when the
     -- object is already gone or otherwise not removable ("Can't remove 0 of 0 items"), and
     -- an engine handler that throws ABORTS — which took the rest of MP_PlayerLeaveWorld
@@ -1447,6 +1529,52 @@ local eventHandlers = {
         spawnPuppet(data.id, pose)
     end,
 
+    -- The world did something to our avatar on the peer (see avatarEffectsTick): a disease
+    -- goes into our spell list; an effect is applied to our own body. Effects applied here
+    -- are flagged to the player script so identity.lua's owner->avatar diff does not send them
+    -- straight back and double them on the avatar.
+    MP_SelfSpells = function(data)
+        if mp.isSystem and mp.isSystem() then return end
+        local player = playerScript()
+        if not player or not data then return end
+        for _, sid in ipairs(data.add or {}) do
+            local localId = worldmp.toLocal(sid)
+            if localId then pcall(function() types.Actor.spells(player):add(localId) end) end
+        end
+    end,
+    MP_SelfActiveSpells = function(data)
+        if mp.isSystem and mp.isSystem() then return end
+        local player = playerScript()
+        if not player or not data then return end
+        local spells = types.Actor.activeSpells(player)
+        for _, sp in ipairs(data.add or {}) do
+            local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId and #(sp.effects or {}) > 0 then
+                toPlayer('MP_PeerEffect', { id = localId, on = true })
+                local ok, err = pcall(function()
+                    spells:add({ id = localId, effects = sp.effects, caster = player, stackable = true,
+                        ignoreResistances = true, ignoreSpellAbsorption = true, ignoreReflect = true })
+                end)
+                if not ok then print('[mp] peer effect apply failed: ' .. tostring(err)) end
+            end
+        end
+        for _, sp in ipairs(data.remove or {}) do
+            local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId then
+                pcall(function()
+                    local victims = {}
+                    for _, active in pairs(spells) do
+                        if active.temporary and active.id == localId and active.activeSpellId then
+                            victims[#victims + 1] = active.activeSpellId
+                        end
+                    end
+                    for _, aid in ipairs(victims) do spells:remove(aid) end
+                end)
+                toPlayer('MP_PeerEffect', { id = localId, on = false })
+            end
+        end
+    end,
+
     -- A guard reached OUR avatar on the peer. Open the dialogue with our copy of that guard:
     -- the local player carries the bounty (CrimeUpdate relay), so vanilla's greeting offers
     -- the fine, the cell, or resisting -- exactly what it would have done had the guard
@@ -1486,8 +1614,10 @@ local eventHandlers = {
         local p = puppets[data.id]
         if not (p and p.obj and p.obj:isValid()) then return end
         local spells = types.Actor.activeSpells(p.obj)
+        ownerActive[data.id] = ownerActive[data.id] or {}
         for _, sp in ipairs(data.add or {}) do
             local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId then ownerActive[data.id][localId] = (ownerActive[data.id][localId] or 0) + 1 end
             if localId and #(sp.effects or {}) > 0 then
                 local ok, err = pcall(function()
                     spells:add({ id = localId, effects = sp.effects, caster = p.obj, stackable = true,
@@ -1501,6 +1631,10 @@ local eventHandlers = {
         -- is the same caveat as stacking above and costs nothing real.
         for _, sp in ipairs(data.remove or {}) do
             local localId = sp.id and worldmp.toLocal(sp.id)
+            if localId and ownerActive[data.id][localId] then
+                ownerActive[data.id][localId] = ownerActive[data.id][localId] - 1
+                if ownerActive[data.id][localId] <= 0 then ownerActive[data.id][localId] = nil end
+            end
             if localId then
                 pcall(function()
                     local victims = {}
@@ -2659,6 +2793,7 @@ return {
                 avatarStatsTick(now) -- Phase 4A: peer reports avatar bars to the server
                 avatarItemStatesTick(now) -- Phase 4D: peer reports avatar wear/charge/soul
                 avatarArrestTick() -- a guard reached a wanted avatar: tell its owner
+                avatarEffectsTick(now) -- disease, paralysis: what the world did to the avatar
             end
         end,
     },

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -820,6 +820,13 @@ local function spawnPuppet(id, pose)
         obj:addScript('scripts/mp/puppet.lua', { playerId = id })
     end
     puppets[id] = { obj = obj, name = name }
+    -- THE WOLF. The appearance relay carries isWerewolf and a change rebuilds the body -- and
+    -- the body was always built a man: nothing set the form on it. A transformed player looked
+    -- human on every other screen, and the avatar fought with human hands on the peer.
+    local app = remoteIdentity[id] and remoteIdentity[id].appearance
+    if app and app.isWerewolf then
+        pcall(function() types.NPC.setWerewolf(obj, true) end)
+    end
     if mp.isSystem and mp.isSystem() then actors.refollow(id, obj) end -- companions aim at the new body
     pushAvatarPolicy()
     applyAvatarDoc(id) -- Phase 2b: a doc that arrived before the body existed lands now

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2462,6 +2462,9 @@ local eventHandlers = {
     mpActorFollow = function(data)
         actors.noteFollow(data and data.actor, data and data.target, data and data.escort)
     end,
+    mpActorCombat = function(data)
+        actors.noteCombat(data and data.actor, data and data.target)
+    end,
 
     mpSocialTab = function(data)
         -- toPlayer, not a world.players loop: the same helper every other player-bound

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2259,15 +2259,24 @@ local eventHandlers = {
     -- (that is the whole point of replaying a one-shot), so broadcasting it would put a
     -- second Staada in front of everyone who already killed theirs.
     mpQuestSpawn = function(data)
-        local player = playerScript()
-        if not player or not data.recordId then return end
+        if not data.recordId then return end
+        -- On the peer the server names the player it is owed to (forId) and the encounter is
+        -- placed beside THEIR avatar, where it is simulated like any other actor in the cell.
+        local anchor
+        if mp.isSystem and mp.isSystem() then
+            local p = data.forId ~= nil and puppets[data.forId]
+            anchor = (p and p.obj and p.obj:isValid()) and p.obj or nil
+        else
+            anchor = playerScript()
+        end
+        if not anchor then return end
         local ok, err = pcall(function()
             local obj = world.createObject(data.recordId)
-            obj:teleport(player.cell, player.position + util.vector3(150, 150, 0))
+            obj:teleport(anchor.cell, anchor.position + util.vector3(150, 150, 0))
         end)
         if ok then
             print('[mp] quest spawn replayed: ' .. tostring(data.recordId))
-            notice('Something stirs nearby.')
+            if not (mp.isSystem and mp.isSystem()) then notice('Something stirs nearby.') end
         else
             print('[mp] quest spawn failed: ' .. tostring(err))
         end

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1207,6 +1207,7 @@ local function start()
     -- global-gated in 0.52 (setCrimeLevel, world.mwscript).
     quests.init({
         playerFn = playerScript,
+        dispositionOutFn = function(obj, d) actors.noteDisposition(obj, d) end,
         ownCellKeyFn = function() return ownCellKeyCache end,
         ownIdFn = function() return net.state == 'Joined' and net.playerId or nil end,
         noticeFn = notice,

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2465,6 +2465,9 @@ local eventHandlers = {
     mpActorCombat = function(data)
         actors.noteCombat(data and data.actor, data and data.target)
     end,
+    mpActorTravel = function(data)
+        actors.noteTravel(data and data.actor, data and data.dest)
+    end,
 
     mpSocialTab = function(data)
         -- toPlayer, not a world.players loop: the same helper every other player-bound

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -170,11 +170,23 @@ end
 -- is seen. Temporary effects only: abilities, diseases and curses ride the spellbook, and
 -- constant-effect enchantments ride equipment, so both are already on the avatar. Keyed by
 -- the engine's own instance id so two potions of the same kind are two entries.
+-- Effects the PEER put on us (global.lua MP_SelfActiveSpells): they came from the avatar, so
+-- they must not go back to it. Counted per record id; MP_PeerEffect on/off maintains it.
+local peerEffects = {}
+function identity.notePeerEffect(id, on)
+    if type(id) ~= 'string' then return end
+    if on then peerEffects[id] = (peerEffects[id] or 0) + 1
+    elseif peerEffects[id] then
+        peerEffects[id] = peerEffects[id] - 1
+        if peerEffects[id] <= 0 then peerEffects[id] = nil end
+    end
+end
+
 local function snapActive()
     local set = {}
     local ok = pcall(function()
         for _, sp in pairs(Actor.activeSpells(self)) do
-            if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil then
+            if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil and not peerEffects[sp.id] then
                 local idx = {}
                 for _, e in ipairs(sp.effects or {}) do
                     if e.index ~= nil then idx[#idx + 1] = e.index end

--- a/openmw/files/data/scripts/mp/net.lua
+++ b/openmw/files/data/scripts/mp/net.lua
@@ -633,7 +633,10 @@ end
 -- somewhere else and reconnecting would have the two sessions fight; RATE means the client was
 -- dropped for flooding, and hammering the door is precisely the wrong reply; BAD_ENGINE /
 -- BAD_CONTENT / BAD_PROTO will refuse identically every time.
-local TRANSIENT_DISCONNECT = { SHUTDOWN = true, SERVER_FULL = true }
+-- IP_CAP: too many sockets from this address RIGHT NOW -- which, for a player, is almost
+-- always their own previous socket still draining after a wifi blip, gone in seconds. A
+-- terminal modal for that would strand the exact person a reconnect exists for.
+local TRANSIENT_DISCONNECT = { SHUTDOWN = true, SERVER_FULL = true, IP_CAP = true }
 
 dispatch.SessionDisconnect = function(msg)
     net.lastError = msg.code

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -811,6 +811,9 @@ return {
         end,
         -- Arrest (global.lua MP_PlayerArrest): the guard that reached our avatar, resolved
         -- to our copy of it. UI modes are player-script-only, hence the hop.
+        MP_PeerEffect = function(data)
+            if data then identity.notePeerEffect(data.id, data.on == true) end
+        end,
         MP_OpenDialogue = function(data)
             local target = data and data.target
             local okv, valid = pcall(function() return target and target:isValid() end)

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -437,12 +437,27 @@ local function requestLock(obj)
     })
 end
 
+local lockDisposition = nil -- the NPC's disposition when the conversation began
+
 function quests.releaseLock(why)
     local obj = lockHeld
     lockHeld = nil
     lockPending = nil
     lockAllowOnce = nil
     if not obj then return end
+    -- Did the conversation change their mind? Admire, intimidate, taunt, bribe all write the
+    -- NPC's base disposition on THIS engine only; tell the holder while the lock still says
+    -- we were the one talking. Sent before the release below on purpose.
+    if lockDisposition ~= nil and deps.dispositionOutFn then
+        local player = playerObj()
+        local okd, now = pcall(function()
+            return player and obj:isValid() and types.NPC.getBaseDisposition(obj, player) or nil
+        end)
+        if okd and type(now) == 'number' and now ~= lockDisposition then
+            deps.dispositionOutFn(obj, now)
+        end
+    end
+    lockDisposition = nil
     mp.sendEvent('DialogueLock', { ref = obj, cellKey = deps.ownCellKeyFn(), want = false })
     mirrorLock({ ref = obj:isValid() and obj.recordId or '?', granted = false, why = why or 'released' })
 end
@@ -689,6 +704,9 @@ handlers.MP_DialogueLockResult = function(data)
     if data.granted then
         lockHeld = obj
         lockAllowOnce = obj.id
+        local player = playerObj()
+        local okd, d = pcall(function() return player and types.NPC.getBaseDisposition(obj, player) or nil end)
+        lockDisposition = (okd and type(d) == 'number') and d or nil
         mirrorLock({ ref = obj.recordId, granted = true })
         -- Re-run the activation we cancelled; this time the handler lets it through.
         local player = playerObj()

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -576,7 +576,7 @@ end
 handlers.MP_QuestSpawn = function(data)
     if type(data.recordId) ~= 'string' then return end
     core.sendGlobalEvent('mpQuestSpawn', {
-        recordId = data.recordId, questId = tostring(data.questId or ''),
+        recordId = data.recordId, questId = tostring(data.questId or ''), forId = data.forId,
     })
 end
 

--- a/server/config.default.toml
+++ b/server/config.default.toml
@@ -191,7 +191,12 @@ bytesBurst = 262144               # 4x rate
 # multiplier so an operator can widen the shed window without also widening the kill window.
 maxBufferedBytes = 262144         # 256 KB ~= 4 s of the byte budget
 maxBufferedBytesHard = 1048576    # 1 MB
-maxConnsPerIp = 3
+# Per source IP. The target audience is friends, and friends share a NAT: a LAN party of four
+# is four sockets from one address, and a reconnect after a wifi blip briefly makes it five
+# while the dying socket drains. 3 refused the fourth friend with conn.ip_cap_refused and
+# nothing on their screen explained it. 8 covers a household with headroom; a flood still
+# hits the per-session budgets long before it hits this.
+maxConnsPerIp = 8
 # Non-adjacent EXTERIOR cell changes allowed per minute, per player. 0 disables.
 #
 # The speed envelope deliberately forgives a cell change, because a door is a teleport — which

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -897,7 +897,12 @@ loot bug already fixed here.
   list -- the avatar falls and drowns too, so accepting client lowers would double them,
   which is why the rule cannot simply be relaxed. Needs the trap/script hit to be forwarded
   to the avatar the way spell hits on puppets are (CombatSpellHit), so it lands once, there.
-  Found 2026-09-10 while fixing the magicka and item-state halves of the same rule. Related:
+  Found 2026-09-10 while fixing the magicka and item-state halves of the same rule.
+  NARROWED 2026-09-11: a trap's spell lands on the client's player as an ACTIVE EFFECT, and
+  PlayerActiveSpells now carries those to the avatar -- so a fire trap with a duration hurts
+  the avatar (once, there) and the bars come back. What is still lost: effects of zero
+  duration (instant Damage Health is applied and gone before the half-second diff sees it)
+  and MWScript writes (ModHealth, lava scripts), which are not effects at all. Related:
   a DISARMED trap is not synced either (locks are; the trap spell is not in the cell doc), so
   a chest one player disarmed is still armed for the next -- harmless today only because the
   trap's damage is then discarded by this same rule.

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -863,7 +863,10 @@ loot bug already fixed here.
   never told to the peer; the peer's guard keeps re-reaching and the prompt returns every
   cooldown. Same class as the dialogue-started AiTravel below: a package stacked on a puppet
   by a dialogue result needs to travel to the holder. The bounty increase from resisting DOES
-  relay, so the player is at least more wanted, not less.
+  relay, so the player is at least more wanted, not less. TAUNTING is the same hole one step
+  earlier: a successful taunt raises the NPC's Fight and starts combat on the talking client's
+  puppet; the disposition change now relays (ActorDisposition from the lock holder), the Fight
+  rating and the combat start do not, so a taunted NPC glares and does nothing on the peer.
 
 * **Dialogue-started AiTravel never reaches the peer.** Follow and Escort now travel from
   the recruiting client (companion.lua -> ActorAI claim), but "AITravel x y z" from a

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -878,7 +878,7 @@ loot bug already fixed here.
   holder's "in combat with player X" bit to ride ActorStatsDynamic (or the pose flags) so the
   client's copy reads as hostile. 2026-09-11.
 
-* **Dialogue-started AiTravel never reaches the peer.** Follow and Escort now travel from
+* ~~**Dialogue-started AiTravel never reaches the peer.**~~ FIXED 2026-09-11: on an AI-off puppet the active package only changes when a script stacks one, so companion.lua reports a Travel destination on change and the server admits it from the (recent) dialogue-lock holder; the holder walks the actor. The poll concern below did not apply to puppets. Original note: Follow and Escort now travel from
   the recruiting client (companion.lua -> ActorAI claim), but "AITravel x y z" from a
   dialogue result -- the guard who walks off to fetch someone, the NPC who leaves the room
   after the conversation -- is the same client-only class and is not reported. It cannot be

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -870,6 +870,14 @@ loot bug already fixed here.
   puppet; the disposition change now relays (ActorDisposition from the lock holder), the Fight
   rating and the combat start do not, so a taunted NPC glares and does nothing on the peer.
 
+* **You can rest mid-fight.** Vanilla refuses to rest while an enemy is in combat with you
+  (getEnemiesNearby reads the NPCs' AiSequence). On a client every NPC is a puppet with its
+  AI off and an empty combat state; the fight is on the peer. So a player being chewed on by
+  a nix-hound can open the rest dialog and sleep -- the peer's rat keeps biting the avatar
+  through it, and the owner wakes up dead or at full health depending on who won. Needs the
+  holder's "in combat with player X" bit to ride ActorStatsDynamic (or the pose flags) so the
+  client's copy reads as hostile. 2026-09-11.
+
 * **Dialogue-started AiTravel never reaches the peer.** Follow and Escort now travel from
   the recruiting client (companion.lua -> ActorAI claim), but "AITravel x y z" from a
   dialogue result -- the guard who walks off to fetch someone, the NPC who leaves the room

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -849,7 +849,9 @@ loot bug already fixed here.
   LYCANTHROPY is explicitly handled: form is a flag on NpcStats, so nothing generic carried
   it, and `identity.lua` captures it with `NPC.isWerewolf` and restores it with
   `NPC.setWerewolf`. It rides `appearance` because that is what it is, and because appearance
-  is relayed -- other players see the wolf rather than a man with a wolf's stats.
+  is relayed -- and until 2026-09-11 that relay only REBUILT the body when the flag changed,
+  it never set the form on the new body, so other players saw a man with a wolf's stats after
+  all. spawnPuppet now calls setWerewolf from the relayed appearance, avatar included.
 
   VAMPIRISM needs nothing of its own. `character.cpp` derives it from the Vampirism MAGIC
   EFFECT magnitude, which comes from the `vampire_<clan>` ABILITY in the spell list --

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -902,7 +902,7 @@ loot bug already fixed here.
   a chest one player disarmed is still armed for the next -- harmless today only because the
   trap's damage is then discarded by this same rule.
 
-* **A disease caught ON THE PEER never reaches the player.** Diseases are spells in the
+* ~~**A disease caught ON THE PEER never reaches the player.**~~ FIXED 2026-09-11: the peer diffs each avatar's spell list against the doc and its temporary effects against what the owner sent (AvatarEffectsBatch); the server persists new spells and relays both to the owner, whose engine applies them (SelfSpells / SelfActiveSpells) and flags them so they are not echoed back. Original note kept below for the reasoning. Diseases are spells in the
   actor's spell list and the client's own list is captured and restored (above) -- but with
   the peer resolving every melee, a diseased creature's bite lands on the AVATAR, and the
   avatar's spell list is a one-way copy (AvatarState in, bars and item states out). The peer

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -880,7 +880,7 @@ loot bug already fixed here.
   stacked after the conversation" signal (the dialogue-close edge plus a package diff on
   that one actor), not a poll. 2026-09-11.
 
-* **A summon is cast twice, and only the peer's one fights.** With PlayerActiveSpells the
+* ~~**A summon is cast twice, and only the peer's one fights.**~~ FIXED 2026-09-11: while a holder simulates the player's cell the engine no longer spawns the local copy (mwmp setLocalSummons, driven by actors.hasHolder in global.lua); the effect stays active on the client with no creature of its own, the peer's is the one that fights. Degraded mode keeps local summons. Original note: With PlayerActiveSpells the
   owner's Summon effect now reaches the avatar and the peer summons a creature that sides
   with it, engages what the avatar engages, and is relayed to every client as a cell actor.
   The owner's OWN engine still summons a local copy as well: a client-only actor with its own

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -858,7 +858,7 @@ loot bug already fixed here.
   and `snapSpells` iterates the whole spell store, abilities included. It persists by the
   same route diseases do.
 
-* **"Resist arrest" starts a fight nobody simulates.** The arrest dialogue now reaches the
+* ~~**"Resist arrest" starts a fight nobody simulates.**~~ FIXED 2026-09-11: the player who was talking to the NPC (dialogue lock, kept for 5 s after release because the consequence lands on "Goodbye") may claim `combat = me` on ActorAI; the holder starts the real Combat package against the avatar. Covers taunts too. Original note: The arrest dialogue now reaches the
   wanted player (PlayerArrest, 2026-09-11), and pay/jail work because they act on the local
   player and the bounty relays. Resisting runs `StartCombat player` on the GUARD -- on the
   owner's client, where the guard is a puppet with AI off, so the fight is cancelled there and

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -895,7 +895,10 @@ loot bug already fixed here.
   list -- the avatar falls and drowns too, so accepting client lowers would double them,
   which is why the rule cannot simply be relaxed. Needs the trap/script hit to be forwarded
   to the avatar the way spell hits on puppets are (CombatSpellHit), so it lands once, there.
-  Found 2026-09-10 while fixing the magicka and item-state halves of the same rule.
+  Found 2026-09-10 while fixing the magicka and item-state halves of the same rule. Related:
+  a DISARMED trap is not synced either (locks are; the trap spell is not in the cell doc), so
+  a chest one player disarmed is still armed for the next -- harmless today only because the
+  trap's damage is then discarded by this same rule.
 
 * **A disease caught ON THE PEER never reaches the player.** Diseases are spells in the
   actor's spell list and the client's own list is captured and restored (above) -- but with

--- a/server/docs/MP-BACKLOG.md
+++ b/server/docs/MP-BACKLOG.md
@@ -870,7 +870,7 @@ loot bug already fixed here.
   puppet; the disposition change now relays (ActorDisposition from the lock holder), the Fight
   rating and the combat start do not, so a taunted NPC glares and does nothing on the peer.
 
-* **You can rest mid-fight.** Vanilla refuses to rest while an enemy is in combat with you
+* ~~**You can rest mid-fight.**~~ FIXED 2026-09-11 the same hour: companion.lua (which runs on every actor on the holder) now reports who the actor is fighting when it is a player, ActorAI carries it as `combat`, and the client stacks a Combat package on its AI-off puppet -- never executed, but readable: rest is refused, greetings stop. Original note: Vanilla refuses to rest while an enemy is in combat with you
   (getEnemiesNearby reads the NPCs' AiSequence). On a client every NPC is a puppet with its
   AI off and an empty combat state; the fight is on the peer. So a player being chewed on by
   a nix-hound can open the rest dialog and sleep -- the peer's rat keeps biting the avatar

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -1,0 +1,142 @@
+# Multiplayer coverage map
+
+Every single-player action, routine and NPC behaviour, mapped to the path it takes in the
+server-centralized model, with its status. This is the checklist the gameplay passes work
+from; MP-BACKLOG.md holds the long-form reasoning for anything marked GAP.
+
+Model in one paragraph: the SERVER holds truth (character docs, cell docs, clock, quest
+state) and relays; ONE SIM PEER per world runs the engine for every occupied cell (NPC AI,
+combat resolution, physics of each player's AVATAR); each CLIENT runs its own engine for
+rendering, UI, dialogue and everything the player does with their own hands, and sees other
+players and NPCs as PUPPETS steered by relayed poses with their AI off. Anything the client
+does that changes the world has to travel; anything the peer does to a player has to come
+back. Status: OK = traced and correct; FIXED = broken until the pass found it (date); GAP =
+known and recorded; N/A = does not exist in single player either.
+
+## 1. Session
+
+| Action | MP path | Status |
+|---|---|---|
+| Sign in (password / SSO ticket) | launcher -> gateway -> world server SessionHello/Login | OK |
+| Create character, chargen | private world `priv-<user>-<char>`; chargen sanctuary keeps the peer out of the cell | OK |
+| Resume after disconnect | resume ticket, same character, world snapshot re-sent; IP_CAP retried | FIXED 09-11 (IP_CAP was terminal RATE) |
+| Join a friend (party) | joinFriend -> ownerWorld (occupied) -> switch -> mayJoinWorld -> chargen gate -> guestSpawn beside owner | FIXED 09-10 |
+| Owner flips party -> private | WorldClosed, 5 s grace, guests switched home | OK |
+| Leave / kick / ban | terminal codes; SUPERSEDED for a second tab | OK |
+| Save / Load / quicksave | refused at StateManager while Joined; menu items hidden | OK |
+
+## 2. Movement and travel
+
+| Action | MP path | Status |
+|---|---|---|
+| Walk/run/sneak/jump | input frame 30 Hz -> avatar on peer -> authoritative pose back; reconciliation | OK |
+| Stance (weapon/spell drawn) | input bits 4-5 -> avatar; pose bit 4 -> puppets | FIXED 09-10 (avatar never drew) |
+| Look pitch | input pitch -> avatar pitchChange | FIXED 09-10 |
+| Doors, load doors | client cell change -> PlayerCellChange -> avatar follow-teleport; door state relayed | OK |
+| Silt strider / boat / guild guide | cell change + time skip request + fare from shared purse | OK |
+| Mark/Recall/Intervention/scripted PositionCell | cell change; far-travel limiter is a signal only | OK |
+| Levitate / Water Walk / Slowfall / Fortify Speed | PlayerActiveSpells -> avatar | FIXED 09-11 |
+| Swimming, drowning, falling | avatar physics; peer-authored bars | OK |
+| Followers through doors | peer moves followers with the avatar; exterior key -> teleport arg | FIXED 09-10 |
+
+## 3. Combat
+
+| Action | MP path | Status |
+|---|---|---|
+| Melee vs NPC | client swing cancelled; avatar swings on peer (stance, use bit) | FIXED 09-10 |
+| Ranged | avatar fires; ammo reconciled via inventory | OK |
+| Blocking, armor, difficulty | peer engine, avatar treated as player for scaling | OK |
+| Spell at NPC (touch/target) | client casts; hit on puppet recorded -> CombatSpellHit -> holder applies record | OK |
+| Self-cast / potion / scroll | PlayerActiveSpells -> avatar (spell stance = Nothing on avatar) | FIXED 09-11 |
+| Cast-on-strike, charge | avatar strike on peer; charge: client both ways, peer lowers | FIXED 09-11 |
+| Summons | effect reaches avatar, peer summons; local copy suppressed while a holder exists | FIXED 09-11 |
+| NPC/creature aggression at players | engageCombat treats avatars as players | FIXED 09-11 |
+| NPC retaliation when hit | actorAttacked treats avatar attacker as player | FIXED 09-11 |
+| Being hit: damage, disease, paralysis | peer bars -> SelfStats; AvatarEffectsBatch -> SelfSpells/SelfActiveSpells | FIXED 09-11 |
+| PvP | server veto (pvp rules) + avatar hit veto on the peer | OK |
+| Death | death edge flushed; respawn plugin; avatar rebuilt; puppet rebuilt on other screens | FIXED 09-10 |
+| Kill credit / GetDeadCount | ActorDeath tally shared | OK (attribution logs only) |
+| Companions fight beside you | siding-with on the peer | OK |
+| Resting refused mid-fight | holder relays combat state; puppet carries Combat package | FIXED 09-11 |
+| Trap / scripted damage | trap effects with duration now mirror; zero-duration and MWScript writes lost | GAP (narrow) |
+
+## 4. Character state
+
+| Action | MP path | Status |
+|---|---|---|
+| hp/mp/ft | peer-authored while driving; client may raise (heal); magicka client both ways | FIXED 09-11 (free casting) |
+| Attributes/skills/level, training, level-up | client diff -> doc -> AvatarState | OK |
+| Skill use from cancelled swings | skill use runs before the Lua cancel | OK |
+| Diseases (caught) | AvatarEffectsBatch -> doc.spells + owner | FIXED 09-11 |
+| Vampirism / lycanthropy | spell list / appearance; werewolf form set on rebuilt bodies | FIXED 09-11 (looked human) |
+| Bounty | live per session; shared crime = party record on every avatar | FIXED 09-11 (host hunted) |
+| Faction rank/expulsion | routed like the journal | OK |
+
+## 5. Inventory and world objects
+
+| Action | MP path | Status |
+|---|---|---|
+| Pick up / two players race | ObjectTakeRequest first-wins, tombstone, refusal shown | OK |
+| Drop | ObjectSpawn, netId, refused reasons incl. cell_full | FIXED 09-10 (no cell_full line) |
+| Containers, merchants' stock and gold | canonical on first open; gold deltas; 24 h restock | OK |
+| Item condition / charge / soul | per-field merge: charge client, condition raise client, soul peer | FIXED 09-11 |
+| Repair / recharge / soul trap | see above | FIXED 09-11 |
+| Quest items never deplete | container rule | OK |
+| Theft, pickpocket, ownership | client-side crime detection; bounty relays | OK |
+| Scripted enable/disable of refs | ObjectEnabled persisted | OK |
+| Locks, lockpicking, script Lock/Unlock | lockWatch relay, persisted | OK |
+| Trap disarm state | not in the cell doc | GAP (harmless while trap damage is discarded) |
+| Cell resets | server sweep; clients handed restored truth | OK |
+| Dynamic records (alchemy, enchant, spellmaking) | RecordsSync chunked; toNet/toLocal at every seam | OK |
+
+## 6. NPC behaviour (the peer as holder)
+
+| Behaviour | MP path | Status |
+|---|---|---|
+| Wander/idle AI, pathing | peer engine; poses 10 Hz relayed; puppets steer | OK |
+| Posture while fighting | actor pose bits 4/5 | FIXED 09-11 |
+| Greetings, idle voice | puppets greet with AI off | FIXED 09-11 |
+| Dialogue (one at a time) | dialogue lock; refusal names the holder | OK |
+| Persuasion (bribe/taunt/admire) | lock holder relays disposition | FIXED 09-11 |
+| Taunt -> fight; resist arrest -> fight | lock holder claims combat; holder starts it | FIXED 09-11 |
+| Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors | FIXED 09-10/11 |
+| Dialogue-started AiTravel | companion.lua reports; lock holder claim | FIXED 09-11 |
+| Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11 |
+| Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |
+| Death, loot, corpse | ActorDeath, corpse container canonical | OK |
+| Content-placed NPCs/creatures | content RefNum, addressable everywhere | OK |
+| **Runtime-spawned actors** (levelled-list creatures, PlaceAtPC/PlaceAtMe, script spawns) | per-engine dynamic RefNums: the peer's creature and the client's are different objects; clients show AI-off statues, the peer's copy fights avatars unseen | **GAP — in progress** (net-actor sync) |
+| Replayed one-shot quest encounters | spawned on the peer beside the avatar | FIXED 09-11 |
+
+## 7. Quests and scripts
+
+| Mechanism | MP path | Status |
+|---|---|---|
+| Journal | shared per instance; guests borrow the host's | OK |
+| Topics learned | shared with the journal | OK |
+| Globals (quest gates) | peer's write wins within the driving window; dialogue-result names client-owned | OK |
+| Member variables on cell scripts | MemberVarUpdate relay | OK |
+| Faction standing, bounty | routed to the campaign | OK |
+| OnDeath / GetDeadCount | shared tally | OK |
+| Scripted PlaceAt / PositionCell of NPCs | see runtime-spawned actors | GAP |
+| Scripted AddItem/RemoveItem on NPCs | runs on every engine identically (deterministic) | OK (by construction) |
+| StartScript/StopScript | runs per engine; globals reconcile | OK |
+
+## 8. World
+
+| Mechanism | MP path | Status |
+|---|---|---|
+| Clock, time scale, rest/wait | server clock; rest policy (owner/anyone/off); refusals told | OK |
+| Weather | WorldWeather authority | OK |
+| Map exploration | shared when enabled | OK |
+
+## 9. Hardening (security / performance)
+
+| Concern | Where | Status |
+|---|---|---|
+| Forged peer-only events (AvatarStats/ItemStates/Effects, PlayerArrest/Crime) | world-peer-only gates, tested | OK |
+| Non-holder actor claims (follow/escort/travel/combat/disposition) | bounded to self / lock holder; follower cap 8 | OK |
+| Client effect floods | PlayerActiveSpells budget 40 ops / 5 s | OK |
+| LSER node ceiling | RecordsSync chunked; cell frame caps | OK |
+| Per-IP cap for households | default 8; IP_CAP transient | FIXED 09-11 |
+| Report spam | per reporter+target cooldown | FIXED 09-10 |

--- a/server/src/core/players.ts
+++ b/server/src/core/players.ts
@@ -97,6 +97,9 @@ export interface Player {
   // guest's murder and let the guest walk. Set on join from the world's view, updated on
   // every CrimeUpdate, and what AvatarState carries.
   bounty?: number;
+  // PlayerActiveSpells budget (playerstate.ts handleActiveSpells).
+  activeOpsWindowAt?: number;
+  activeOpsInWindow?: number;
   // Sliding-window budget for CLIENT-asserted restoration while the peer owns this player's
   // bars (potions, rest, self-heal -- all still client-side until the intent tier). Without a
   // bound, "a raise is a restoration" is an immortality exploit: a modified client claims full

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -616,6 +616,56 @@ function handleActiveSpells(ctx: StateCtx, player: Player, body: LTable): boolea
   return true;
 }
 
+// WHAT THE WORLD DID TO THE AVATAR, from the peer (global.lua avatarEffectsTick): spells the
+// avatar acquired (a disease from a bite) and temporary effects landed on it (Paralyze, Burden,
+// Silence from a hostile caster). Spells are persisted -- a disease is a fact about the
+// character -- and both halves go to the owner's client, which applies them to the body the
+// player is actually looking at. World peer only: a client saying this would be cursing others.
+export function handleAvatarEffectsBatch(ctx: StateCtx, sender: Player, value: LValue | undefined): void {
+  if (sender.system !== true || sender !== ctx.worldPeer()) return;
+  const body = tbl(value);
+  const entries = body ? tbl(body.get('entries')) : undefined;
+  if (!entries || entries.size > MAX_ACTIVE_SPELL_OPS) return;
+  for (const [, ev] of entries) {
+    const e = tbl(ev);
+    if (!e) continue;
+    const id = finite(e.get('id'));
+    const p = id !== undefined ? ctx.roster.get(id) : undefined;
+    if (!p || p.system === true || !p.inWorld) continue;
+    const spellsAdd: string[] = [];
+    const rawSpells = tbl(e.get('spellsAdd'));
+    if (rawSpells) {
+      if (rawSpells.size > MAX_ACTIVE_SPELL_OPS) continue;
+      for (const [, sv] of rawSpells) { const sid = recordId(sv); if (!sid) { spellsAdd.length = 0; break; } spellsAdd.push(sid); }
+    }
+    const ops = (v: LValue | undefined, withEffects: boolean): ActiveOp[] => {
+      const t = tbl(v); const out: ActiveOp[] = [];
+      if (!t || t.size > MAX_ACTIVE_SPELL_OPS) return out;
+      for (const [, ov] of t) {
+        const o = tbl(ov); const rid = o ? recordId(o.get('id')) : undefined;
+        if (!o || !rid) return [];
+        if (!withEffects) { out.push({ key: rid, id: rid }); continue; }
+        const fx = tbl(o.get('effects')); const effects: number[] = [];
+        if (!fx || fx.size === 0 || fx.size > MAX_EFFECT_INDEXES) return [];
+        for (const [, iv] of fx) { const i = finite(iv); if (i === undefined || !Number.isInteger(i) || i < 0 || i >= MAX_EFFECT_INDEXES) return []; effects.push(i); }
+        out.push({ key: rid, id: rid, effects });
+      }
+      return out;
+    };
+    const add = ops(e.get('effectsAdd'), true);
+    const remove = ops(e.get('effectsRemove'), false);
+    if (spellsAdd.length > 0) {
+      ctx.store.update(p.charId, (doc) => {
+        const have = new Set(doc.spells ?? []);
+        for (const sid of spellsAdd) have.add(sid);
+        doc.spells = [...have].slice(0, MAX_SPELLS);
+      }, 'now');
+      p.peer.sendEvent('SelfSpells', { add: spellsAdd });
+    }
+    if (add.length > 0 || remove.length > 0) p.peer.sendEvent('SelfActiveSpells', { add, remove });
+  }
+}
+
 const HANDLERS: Record<string, (ctx: StateCtx, player: Player, body: LTable) => boolean> = {
   PlayerActiveSpells: handleActiveSpells,
   PlayerAppearance: handleAppearance,

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -563,6 +563,8 @@ export function handleAvatarItemStatesBatch(ctx: StateCtx, sender: Player, value
 // stored: an effect is as long-lived as its duration, and the avatar re-derives nothing from
 // the doc. Validated for shape and bounded, then forwarded to the world peer verbatim.
 const MAX_ACTIVE_SPELL_OPS = 32;
+const ACTIVE_OPS_WINDOW_MS = 5_000;
+const ACTIVE_OPS_BUDGET = 40; // adds+removes per window; a potion binge is a handful
 const MAX_EFFECT_INDEXES = 8; // ESM spells carry at most 8 effects
 type ActiveOp = { key: string; id: string; effects?: number[] };
 function handleActiveSpells(ctx: StateCtx, player: Player, body: LTable): boolean {
@@ -593,6 +595,20 @@ function handleActiveSpells(ctx: StateCtx, player: Player, body: LTable): boolea
   const add = list(body.get('add'), true);
   const remove = list(body.get('remove'), false);
   if (!add || !remove) return false;
+  // THE PEER PAYS FOR EVERY ADD. An honest client diffs at 0.5 s and a potion is one entry;
+  // 60 messages a second of 32 adds each is a way to make the world's one simulator spend
+  // its frame on activeSpells:add. Budgeted per player, and over budget is dropped and
+  // counted -- the same "signal, never an action" shape as the movement envelope.
+  const nowMs = Date.now();
+  if (player.activeOpsWindowAt === undefined || nowMs - player.activeOpsWindowAt > ACTIVE_OPS_WINDOW_MS) {
+    player.activeOpsWindowAt = nowMs;
+    player.activeOpsInWindow = 0;
+  }
+  player.activeOpsInWindow = (player.activeOpsInWindow ?? 0) + add.length + remove.length;
+  if (player.activeOpsInWindow > ACTIVE_OPS_BUDGET) {
+    noteGain(ctx, player, 'active_spell_flood', { inWindow: player.activeOpsInWindow });
+    return true; // consumed, not forwarded
+  }
   const worldPeer = ctx.worldPeer();
   if (worldPeer && (add.length > 0 || remove.length > 0)) {
     worldPeer.peer.sendEvent('AvatarActiveSpells', { id: player.id, add, remove });

--- a/server/src/core/quests.ts
+++ b/server/src/core/quests.ts
@@ -553,7 +553,13 @@ export class Quests {
     }
     const held = this.dialogueLocks.get(ref.key);
     if (!want) {
-      if (held?.playerId === player.id) this.dialogueLocks.delete(ref.key);
+      if (held?.playerId === player.id) {
+        this.dialogueLocks.delete(ref.key);
+        // A dialogue's consequences land AFTER the window closes -- a taunted NPC or a guard
+        // whose arrest was resisted starts combat on "Goodbye" -- and the client's report of
+        // that state polls at 1 Hz. Keep "who was just talking to it" for a moment.
+        this.recentlyHeld.set(ref.key, { playerId: player.id, at: Date.now() });
+      }
       player.peer.sendEvent('DialogueLockResult', { ref: refBody(ref), granted: false });
       return;
     }
@@ -575,8 +581,15 @@ export class Quests {
     }
   }
 
+  private readonly recentlyHeld = new Map<string, { playerId: number; at: number }>();
+  private static readonly RECENT_LOCK_MS = 5_000;
   dialogueHolder(refKey: string): number | undefined {
-    return this.dialogueLocks.get(refKey)?.playerId;
+    const live = this.dialogueLocks.get(refKey)?.playerId;
+    if (live !== undefined) return live;
+    const recent = this.recentlyHeld.get(refKey);
+    if (recent && Date.now() - recent.at <= Quests.RECENT_LOCK_MS) return recent.playerId;
+    if (recent) this.recentlyHeld.delete(refKey);
+    return undefined;
   }
 }
 

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -199,6 +199,9 @@ export class WorldState {
 
   /** Set by the server: a cell gained an authority holder. See the grant callback below. */
   onHolderGained?: (cellKey: string) => void;
+  // Who holds the conversation lock on an NPC (quests.ts). Wired by server.ts; the second
+  // actor fact a non-holder may state hangs off it (see actorEvent, ActorDisposition).
+  dialogueHolder?: (refKey: string) => number | undefined;
 
   constructor(
     private readonly roster: Roster,
@@ -506,6 +509,26 @@ export class WorldState {
     }
     if (name === 'ActorAI' && this.authority.holderOf(str(body.get('cellKey'), MAX_CELL_KEY) ?? '') !== player.id) {
       this.followClaim(player, body);
+      return;
+    }
+    if (name === 'ActorDisposition' && this.authority.holderOf(str(body.get('cellKey'), MAX_CELL_KEY) ?? '') !== player.id) {
+      // PERSUASION HAPPENS IN A DIALOGUE, on the talking player's client -- never the holder
+      // on a peer-simulated world -- so under the holder-only rule a bribe or a taunt changed
+      // an NPC's mind on one screen and nowhere else. The one player who may say how the NPC
+      // now feels is the one the server let talk to it: the dialogue-lock holder, while the
+      // lock stands (the client sends this before releasing). Bounded to that, and to [0,100].
+      const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
+      const ref = parseObjRef(body);
+      const disposition = finite(body.get('disposition'));
+      if (!cellKey || !ref || ref.kind !== 'ref' || disposition === undefined || disposition < 0 || disposition > 100) {
+        this.invalid(player, name);
+        return;
+      }
+      if (player.system || this.dialogueHolder?.(ref.key) !== player.id || !cellsVisible(player.cellKey, cellKey)) {
+        log('warn', 'actor.dropped', { from: player.name, name, cellKey, why: 'disposition without the conversation' });
+        return;
+      }
+      this.relayCellExcept(cellKey, player.id, name, { ...lToJs(body) as Record<string, JsLike> });
       return;
     }
     const checked = this.authCheck(player, body, name);

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -518,6 +518,27 @@ export class WorldState {
       return;
     }
     if (name === 'ActorAI' && this.authority.holderOf(str(body.get('cellKey'), MAX_CELL_KEY) ?? '') !== player.id) {
+      if (body.get('travel') !== undefined) {
+        // "THIS NPC NOW WALKS TO X", a dialogue result (AITravel) -- same admission as the
+        // combat claim below: the player who was just talking to it, near the cell, finite
+        // in-world coordinates. The holder walks the real actor there.
+        const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
+        const ref = parseObjRef(body);
+        const t = body.get('travel');
+        const tt = t instanceof Map ? t as LTable : undefined;
+        const x = tt ? finite(tt.get('x')) : undefined, y = tt ? finite(tt.get('y')) : undefined, z = tt ? finite(tt.get('z')) : undefined;
+        if (!cellKey || !ref || ref.kind !== 'ref' || x === undefined || y === undefined || z === undefined
+          || Math.abs(x) > MAX_ABS_COORD || Math.abs(y) > MAX_ABS_COORD || Math.abs(z) > MAX_ABS_COORD) {
+          this.invalid(player, name);
+          return;
+        }
+        if (player.system || this.dialogueHolder?.(ref.key) !== player.id || !cellsVisible(player.cellKey, cellKey)) {
+          log('warn', 'actor.dropped', { from: player.name, name, cellKey, why: 'travel claim without the conversation' });
+          return;
+        }
+        this.relayCellExcept(cellKey, player.id, name, { ...lToJs(body) as Record<string, JsLike> });
+        return;
+      }
       if (body.get('combat') !== undefined) {
         // "THIS NPC NOW FIGHTS ME." A taunt, or resisting arrest, starts combat as a dialogue
         // result -- on the talking player's client, where the NPC is a puppet, so the fight

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -518,6 +518,22 @@ export class WorldState {
       return;
     }
     if (name === 'ActorAI' && this.authority.holderOf(str(body.get('cellKey'), MAX_CELL_KEY) ?? '') !== player.id) {
+      if (body.get('combat') !== undefined) {
+        // "THIS NPC NOW FIGHTS ME." A taunt, or resisting arrest, starts combat as a dialogue
+        // result -- on the talking player's client, where the NPC is a puppet, so the fight
+        // never reached the holder and the NPC glared. The player who was just talking to it
+        // may say so, about themselves only; the holder starts the real fight.
+        const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
+        const ref = parseObjRef(body);
+        const combat = finite(body.get('combat'));
+        if (!cellKey || !ref || ref.kind !== 'ref' || combat !== player.id) { this.invalid(player, name); return; }
+        if (player.system || this.dialogueHolder?.(ref.key) !== player.id || !cellsVisible(player.cellKey, cellKey)) {
+          log('warn', 'actor.dropped', { from: player.name, name, cellKey, why: 'combat claim without the conversation' });
+          return;
+        }
+        this.relayCellExcept(cellKey, player.id, name, { ...lToJs(body) as Record<string, JsLike> });
+        return;
+      }
       this.followClaim(player, body);
       return;
     }

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -446,6 +446,7 @@ export class WorldState {
   // the holder's ActorCellChange) so a claim can be replayed to whoever next holds that cell
   // -- the peer restarts, and a fresh process has never heard who follows whom.
   private readonly followedBy = new Map<string, { ref: ObjRef; cellKey: string; follow: number; escort?: Record<string, number> }>();
+  private static readonly MAX_FOLLOWERS = 8;
   private replayFollows(holderId: number, cellKey: string): void {
     const holder = this.roster.get(holderId);
     if (!holder) return;
@@ -485,6 +486,15 @@ export class WorldState {
       if (this.followedBy.get(ref.key)?.follow !== player.id) return; // not yours to dismiss
       this.followedBy.delete(ref.key);
     } else {
+      // A recruit needs a conversation; a claim needs a message. Vanilla has no cap because
+      // it has no forged claims. Eight is more companions than any quest hands out at once,
+      // and it stops "every guard in Balmora follows me" from being one loop on a modified client.
+      let mine = 0;
+      for (const f of this.followedBy.values()) if (f.follow === player.id) mine++;
+      if (mine >= WorldState.MAX_FOLLOWERS && this.followedBy.get(ref.key)?.follow !== player.id) {
+        log('warn', 'actor.dropped', { from: player.name, name: 'ActorAI', cellKey, why: 'follower cap' });
+        return;
+      }
       this.followedBy.set(ref.key, { ref, cellKey, follow, ...(escort ? { escort } : {}) });
     }
     this.relayCellExcept(cellKey, player.id, 'ActorAI', { ...lToJs(body) as Record<string, JsLike> });

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -1055,8 +1055,17 @@ export class Connection implements Peer {
     // before they ever got here.
     queueMicrotask(() => {
       const owed = this.ctx.questSpawnsOnEntry?.(player, cellKey) ?? [];
+      // WHERE IT IS SPAWNED IS WHERE IT IS SIMULATED. Replayed on the player's own client
+      // this actor was local to one engine in a cell the peer holds: the client's non-holder
+      // sweep puppeted it with its AI off, the player's swings at it were cancelled as the
+      // peer's job, and the peer had never heard of it -- a statue where the fight should be.
+      // With a world peer the encounter is spawned THERE, beside the player's avatar, so it is
+      // a real simulated actor everyone in the cell sees and fights. No peer: as before.
+      const peer = this.ctx.worldPeer();
       for (const spawn of owed) {
-        player.peer.sendEvent('QuestSpawn', { recordId: spawn.recordId, questId: spawn.questId, cellKey });
+        const body = { recordId: spawn.recordId, questId: spawn.questId, cellKey };
+        if (peer) peer.peer.sendEvent('QuestSpawn', { ...body, forId: player.id });
+        else player.peer.sendEvent('QuestSpawn', body);
       }
     });
     player.teleportPose = { x, y, z, at: Date.now(), seq: player.inputSeq ?? 0 }; // peer poses ignored until the avatar arrives (players.ts)

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -38,7 +38,7 @@ const MAX_CELLS_PER_SESSION = 4096;
  *  is invisible to a person and ends a flood without disconnecting anybody. */
 const CHAT_PER_SEC = 5;
 const CHAT_BURST = 20;
-import { handleAvatarItemStatesBatch, handleAvatarStatsBatch, handleStateEvent, syncStateOnJoin, type StateCtx } from '../core/playerstate';
+import { handleAvatarEffectsBatch, handleAvatarItemStatesBatch, handleAvatarStatsBatch, handleStateEvent, syncStateOnJoin, type StateCtx } from '../core/playerstate';
 import type { WorldState } from '../core/worldstate';
 import type { Combat } from '../core/combat';
 import type { Quests } from '../core/quests';
@@ -667,6 +667,12 @@ export class Connection implements Peer {
     if (name === 'AvatarItemStatesBatch') {
       // Phase 4D: the peer's avatar wear/charge/soul reports (system-only).
       handleAvatarItemStatesBatch(this.ctx.stateCtx, this.player, value);
+      return;
+    }
+    if (name === 'AvatarEffectsBatch') {
+      // The peer reports what the world did to each avatar (disease, hostile effects); the
+      // owner's client applies it to the body the player sees. System-only, checked inside.
+      handleAvatarEffectsBatch(this.ctx.stateCtx, this.player, value);
       return;
     }
     if (name === 'PlayerCrime') {

--- a/server/src/proto/session.ts
+++ b/server/src/proto/session.ts
@@ -108,6 +108,7 @@ export type DisconnectCode =
   | 'SUPERSEDED'
   | 'KICKED'
   | 'RATE'
+  | 'IP_CAP'
   | 'SERVER_FULL'
   | 'SHUTDOWN';
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1494,8 +1494,11 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
     if (!ipTracker.acquire(ip)) {
       log('info', 'conn.ip_cap_refused', { ip });
       metrics.connRefused.inc({ reason: 'ip_cap' });
-      if (ws.readyState === WebSocket.OPEN) ws.send(disconnectMsg('RATE', 'too many connections from your address'));
-      ws.close(1008, 'RATE');
+      // IP_CAP, not RATE: RATE is terminal on the client (a flood is not re-litigated by a
+      // retry), but for a player this is almost always their own dying socket after a wifi
+      // blip still counting against the address for a few seconds. The client retries this one.
+      if (ws.readyState === WebSocket.OPEN) ws.send(disconnectMsg('IP_CAP', 'too many connections from your address'));
+      ws.close(1008, 'IP_CAP');
       return;
     }
     // Setup mode: the admin surface is up so the operator can finish configuring, but there

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -532,6 +532,7 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
     worldGlobals: config.sharing.worldGlobals,
     worldPeer: () => worldPeerImpl(),
   });
+  world.dialogueHolder = (refKey) => quests.dialogueHolder(refKey);
 
   // Phase C. The store is opened here so its lifetime matches the server's; social.stop()
   // clears presence timers that would otherwise keep the process alive on shutdown.

--- a/server/test/avatarstats.test.ts
+++ b/server/test/avatarstats.test.ts
@@ -202,3 +202,33 @@ test("a client's active effects are forwarded to the peer for the avatar, and ga
   assert.equal((next.value as { add: { id: string }[] }).add[0]!.id, 'fortify_speed',
     'the malformed message was dropped, the well-formed one after it was forwarded');
 });
+
+// WHAT THE WORLD DID TO THE AVATAR comes back. A bite on the peer puts a disease in the avatar's
+// spell list; a hostile Paralyze lands on it as an effect. Both must reach the owner's own body,
+// the disease persisted; and no client may curse another by sending the batch itself.
+test("the peer's report of a disease and a hostile effect reaches the owner; a client's does not", async (t) => {
+  const { server, peer, a } = await world(t);
+  a.inbox.events.length = 0;
+  peer.sendEvent('AvatarEffectsBatch', { entries: [{
+    id: a.playerId, spellsAdd: ['ataxia'],
+    effectsAdd: [{ id: 'paralyze', effects: [0] }], effectsRemove: [{ id: 'burden' }],
+  }] });
+  const spells = await a.waitEvent('SelfSpells');
+  assert.deepEqual((spells.value as { add: string[] }).add, ['ataxia'], 'the disease reaches the owner');
+  const fx = await a.waitEvent('SelfActiveSpells');
+  const v = fx.value as { add: { id: string; effects: number[] }[]; remove: { id: string }[] };
+  assert.equal(v.add[0]!.id, 'paralyze'); assert.deepEqual(v.add[0]!.effects, [0]);
+  assert.equal(v.remove[0]!.id, 'burden');
+  // Persisted: a rejoin restores the disease (the record the welcome carries lists it).
+  await server.flush();
+
+  const b = await TestClient.connect(server.port);
+  t.after(() => b.close());
+  await b.joinAsNew('Curser');
+  await b.waitEvent('PlayerList');
+  a.inbox.events.length = 0;
+  b.sendEvent('AvatarEffectsBatch', { entries: [{ id: a.playerId, spellsAdd: ['corprus'] }] });
+  b.sendEvent('ChatSend', { text: 'cursefence' });
+  await a.waitEvent('ChatMessage', (vv) => (vv as { text?: string }).text === 'cursefence');
+  assert.equal(a.inbox.events.filter((e) => e.name === 'SelfSpells').length, 0, 'a client cursed another player');
+});

--- a/server/test/questrepair.test.ts
+++ b/server/test/questrepair.test.ts
@@ -94,3 +94,52 @@ test('the whitelist is an honest allowlist, not a blanket claim', async () => {
     'unlisted quests still play — they just do not claim the per-character guarantees');
   await w.close();
 });
+
+// WHERE THE REPLAY LANDS. On a world with a sim peer the encounter is spawned on the PEER,
+// beside the owed player's avatar, so it is a simulated actor everyone fights -- not a local
+// actor the client's non-holder sweep turns into a statue. Without a peer, on the client.
+import { startServer } from '../src/server';
+import { TestClient } from './helpers';
+const PEER_PASS = 'peer-secret-1';
+
+test('a replayed encounter is spawned on the peer when there is one, else on the client', async (t) => {
+  const server = await startServer({
+    requireGameData: false, dataDir: tmpDataDir(), port: 0, host: '127.0.0.1',
+    configOverride: { server: { password: PEER_PASS }, sharing: { journal: false } },
+  });
+  t.after(() => server.close());
+  const a = await TestClient.connect(server.port);
+  t.after(() => a.close());
+  const welcome = await a.joinAsNew('Pilgrim');
+  await a.waitEvent('PlayerList');
+  a.sendEvent('JournalEntry', { questId: 'da_azura', index: 10 });
+  await new Promise((r) => setTimeout(r, 200));
+
+  // No peer: the client is told.
+  a.sendCellChange("azura's coast region", 0, 0, 0);
+  const local = await a.waitEvent('QuestSpawn');
+  assert.equal((local.value as { recordId?: string }).recordId, 'staada');
+  assert.equal((local.value as { forId?: unknown }).forId, undefined);
+
+  // With a peer: the peer is told, for this player, and the client is not.
+  const peer = await TestClient.simPeer(server.port, PEER_PASS);
+  t.after(() => peer.close());
+  // The first character is inside the 900 s replay cooldown, so routing is proved on a
+  // SECOND owed character rather than by re-entering.
+  const b = await TestClient.connect(server.port);
+  t.after(() => b.close());
+  const wb = await b.joinAsNew('Second');
+  const bId = wb['playerId'] as number;
+  await b.waitEvent('PlayerList');
+  b.sendEvent('JournalEntry', { questId: 'da_azura', index: 10 });
+  await new Promise((r) => setTimeout(r, 200));
+  b.inbox.events.length = 0;
+  b.sendCellChange("azura's coast region", 0, 0, 0);
+  const onPeer = await peer.waitEvent('QuestSpawn');
+  assert.equal((onPeer.value as { recordId?: string }).recordId, 'staada');
+  assert.equal((onPeer.value as { forId?: number }).forId, bId, 'the peer is told whose encounter it is');
+  b.sendEvent('ChatSend', { text: 'spawnfence' });
+  await b.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'spawnfence');
+  assert.equal(b.inbox.events.filter((e) => e.name === 'QuestSpawn').length, 0,
+    'the client was ALSO told, and would spawn a second local statue');
+});

--- a/server/test/quests.test.ts
+++ b/server/test/quests.test.ts
@@ -263,6 +263,16 @@ test('dialogue lock', async (t) => {
     b.sendEvent('ChatSend', { text: 'combatfence' });
     await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'combatfence');
     assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0, 'a bystander set an NPC on someone');
+    // ...and where a dialogue sent it (AITravel on Goodbye): same admission.
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorAI', { ref: NPC_REF, cellKey: '0,0', epoch: 0, travel: { x: 10, y: 20, z: 30 } });
+    const walk = await b.waitEvent('ActorAI');
+    assert.deepEqual((walk.value as { travel?: unknown }).travel, { x: 10, y: 20, z: 30 }, 'the destination reaches the holder');
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { ref: NPC_REF, cellKey: '0,0', epoch: 0, travel: { x: 1, y: 2, z: 3 } });
+    b.sendEvent('ChatSend', { text: 'travelfence' });
+    await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'travelfence');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0, 'a bystander sent an NPC walking');
     // Re-take the lock so the release subtest below still has something to release.
     a.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '0,0', want: true });
     await a.waitEvent('DialogueLockResult');

--- a/server/test/quests.test.ts
+++ b/server/test/quests.test.ts
@@ -231,6 +231,20 @@ test('dialogue lock', async (t) => {
     assert.deepEqual((await b.waitEvent('DialogueLockResult')).value, { ref: NPC2_REF, granted: true });
   });
 
+  // PERSUASION: the one talking may say how the NPC now feels; anyone else may not.
+  await t.test('the lock holder may relay the disposition it changed; a bystander may not', async () => {
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorDisposition', { ref: NPC_REF, cellKey: '0,0', epoch: 0, disposition: 75 });
+    const got = await b.waitEvent('ActorDisposition');
+    assert.equal((got.value as { disposition?: number }).disposition, 75, 'the bribe reaches the other screen');
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorDisposition', { ref: NPC_REF, cellKey: '0,0', epoch: 0, disposition: 5 }); // not talking to them
+    b.sendEvent('ChatSend', { text: 'dispfence' });
+    await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'dispfence');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorDisposition').length, 0,
+      "a bystander changed an NPC's mind without talking to it");
+  });
+
   await t.test('explicit release frees the NPC', async () => {
     a.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '0,0', want: false });
     await a.waitEvent('DialogueLockResult');

--- a/server/test/quests.test.ts
+++ b/server/test/quests.test.ts
@@ -245,6 +245,29 @@ test('dialogue lock', async (t) => {
       "a bystander changed an NPC's mind without talking to it");
   });
 
+  // TAUNT / RESIST ARREST: the one who was talking may say the NPC now fights THEM, even a
+  // moment after the window closed; never someone else, never about a third player.
+  await t.test('the lock holder may say the NPC now fights them, for a few seconds after release', async () => {
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorAI', { ref: NPC_REF, cellKey: '0,0', epoch: 0, combat: aId });
+    const fight = await b.waitEvent('ActorAI');
+    assert.equal((fight.value as { combat?: number }).combat, aId, 'the holder is told who the NPC fights');
+    a.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '0,0', want: false });
+    await a.waitEvent('DialogueLockResult');
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorAI', { ref: NPC_REF, cellKey: '0,0', epoch: 0, combat: aId }); // just after Goodbye
+    const late = await b.waitEvent('ActorAI');
+    assert.equal((late.value as { combat?: number }).combat, aId, 'the consequence lands after the window closes');
+    a.inbox.events.length = 0;
+    b.sendEvent('ActorAI', { ref: NPC_REF, cellKey: '0,0', epoch: 0, combat: aId }); // Bob: not talking, not about himself
+    b.sendEvent('ChatSend', { text: 'combatfence' });
+    await a.waitEvent('ChatMessage', (v) => (v as { text?: string }).text === 'combatfence');
+    assert.equal(a.inbox.events.filter((e) => e.name === 'ActorAI').length, 0, 'a bystander set an NPC on someone');
+    // Re-take the lock so the release subtest below still has something to release.
+    a.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '0,0', want: true });
+    await a.waitEvent('DialogueLockResult');
+  });
+
   await t.test('explicit release frees the NPC', async () => {
     a.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '0,0', want: false });
     await a.waitEvent('DialogueLockResult');

--- a/server/test/ratelimit.test.ts
+++ b/server/test/ratelimit.test.ts
@@ -12,7 +12,7 @@ test('rate limits', async (t) => {
     dataDir: tmpDataDir(),
     port: 0,
     host: '127.0.0.1',
-    configOverride: { limits: { msgsPerSec: 10 } },
+    configOverride: { limits: { msgsPerSec: 10, maxConnsPerIp: 3 } },
   });
   t.after(() => server.close());
 
@@ -28,7 +28,7 @@ test('rate limits', async (t) => {
   await t.test('4th connection from the same IP is refused', async () => {
     const conns = await Promise.all([1, 2, 3].map(() => TestClient.connect(server.port)));
     const fourth = await TestClient.connect(server.port);
-    await fourth.waitDisconnect('RATE');
+    await fourth.waitDisconnect('IP_CAP');
     const { code } = await fourth.closed;
     assert.equal(code, 1008);
     // The first three are still alive and usable.


### PR DESCRIPTION
Everything one screen saw and the world did not, fixed at the seam it was lost at. Each commit carries its own account.

- **Persuasion:** `ActorDisposition` was holder-only; the dialogue-lock holder may now relay it. Test.
- **Replayed quest encounters** spawned as an AI-off statue on the owed client; with a peer they spawn on the peer beside the avatar. Test.
- **Greetings:** puppets never greeted (inside the AI block). Engine.
- **Werewolf players** looked human everywhere else (flag relayed, form never set).
- **Disease / hostile effects** landed on the avatar and never reached the owner: peer→owner `AvatarEffectsBatch` (spells persisted; effects applied to the owner's body, flagged so they are not echoed back). Test.
- **Duplicate summons:** the local copy is suppressed while a holder simulates the cell. Engine.
- **Resting mid-fight / greeting from a hostile:** the holder relays who an NPC fights; the client's puppet carries the Combat state.
- **Taunt / resist arrest:** the dialogue-lock holder (5 s grace after release) may claim the NPC now fights them; the holder starts the real fight. Test.
- Hardening: follower claims capped at 8; `PlayerActiveSpells` budgeted.

tsc clean; Lua runner 90/90; full suite green at each server change; native peer compiled with both engine edits before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)