### PR TITLE
Every wild creature was two creatures: the peer's, unseen, and yours, a statue

### DIFF
--- a/openmw/apps/openmw/mwclass/creaturelevlist.cpp
+++ b/openmw/apps/openmw/mwclass/creaturelevlist.cpp
@@ -1,5 +1,7 @@
 #include "creaturelevlist.hpp"
 
+#include "../mwmp/puppets.hpp"
+
 #include <components/esm3/actoridconverter.hpp>
 #include <components/esm3/creaturelevliststate.hpp>
 #include <components/esm3/loadlevlist.hpp>
@@ -123,7 +125,14 @@ namespace MWClass
             store.get<ESM::CreatureLevList>().find(ptr.getCellRef().getRefId()), true, prng,
             avatarLevel > 0 ? std::optional<int>(avatarLevel) : std::nullopt);
 
-        if (!id.empty())
+        // Multiplayer client: the peer rolls this list and its creature arrives as a net
+        // object (mwmp/puppets.hpp localSpawnsEnabled). Rolling here too would put a second,
+        // differently-rolled creature in the cell that only this screen has.
+        if (!id.empty() && !MWMP::localSpawnsEnabled())
+        {
+            customData.mSpawn = false;
+        }
+        else if (!id.empty())
         {
             // Delete the previous creature
             MWWorld::Ptr previous = customData.getSpawnedPtr();

--- a/openmw/apps/openmw/mwmp/luabindings.cpp
+++ b/openmw/apps/openmw/mwmp/luabindings.cpp
@@ -163,9 +163,19 @@ namespace MWMP
             {
                 sol::table e = value.as<sol::table>();
                 sol::object obj = e["obj"];
-                if (!obj.is<MWLua::Object>())
+                ESM::RefNum ref;
+                if (obj.is<MWLua::Object>())
+                    ref = obj.as<MWLua::Object>().id();
+                else if (e["net"].is<double>())
+                {
+                    // A runtime-spawned actor has no content RefNum anyone else shares; it is
+                    // addressed by the server's net id, marked with contentFile -2 on the wire
+                    // (netmanager.cpp decodes it back to `net`). -1 is the engine's own "dynamic".
+                    ref.mIndex = static_cast<uint32_t>(e["net"].get<double>());
+                    ref.mContentFile = -2;
+                }
+                else
                     continue;
-                ESM::RefNum ref = obj.as<MWLua::Object>().id();
                 entries.push_back({ ref.mIndex, ref.mContentFile, e.get_or("x", 0.f), e.get_or("y", 0.f),
                     e.get_or("z", 0.f), e.get_or("yaw", 0.f), e.get_or("pitch", 0.f), e.get_or("animVel", 0.f),
                     static_cast<uint8_t>(e.get_or("flags", 0)) });
@@ -265,6 +275,7 @@ namespace MWMP
         };
         // Client: whether the player's own Summon effects spawn a creature HERE (see puppets.hpp).
         api["setLocalSummons"] = [](bool enabled) { setLocalSummons(enabled); };
+        api["setLocalSpawns"] = [](bool enabled) { setLocalSpawns(enabled); };
         api["isEnabled"] = []() { return std::getenv("OPENMW_MP_URL") != nullptr; };
         api["getUrl"] = []() { return getEnvString("OPENMW_MP_URL"); };
         api["getName"] = []() { return getEnvString("OPENMW_MP_NAME"); };

--- a/openmw/apps/openmw/mwmp/netmanager.cpp
+++ b/openmw/apps/openmw/mwmp/netmanager.cpp
@@ -474,7 +474,14 @@ namespace MWMP
                     const uint8_t* pose = e + 8; // after the 8-byte ref
                     lserNumber(body, static_cast<double>(i + 1));
                     body.push_back(0x3); // TABLE_START (entry)
-                    lserRefKV(body, "ref", readLE<uint32_t>(e), static_cast<int32_t>(readLE<uint32_t>(e + 4)));
+                    {
+                        const uint32_t index = readLE<uint32_t>(e);
+                        const int32_t contentFile = static_cast<int32_t>(readLE<uint32_t>(e + 4));
+                        if (contentFile == -2)
+                            lserKV(body, "net", static_cast<double>(index)); // net-addressed actor
+                        else
+                            lserRefKV(body, "ref", index, contentFile);
+                    }
                     lserKV(body, "x", readF32(pose));
                     lserKV(body, "y", readF32(pose + 4));
                     lserKV(body, "z", readF32(pose + 8));

--- a/openmw/apps/openmw/mwmp/puppets.hpp
+++ b/openmw/apps/openmw/mwmp/puppets.hpp
@@ -116,6 +116,12 @@ namespace MWMP
      *  scripts/mp (mp.setLocalSummons) from the cell's holder state; default on (singleplayer). */
     void setLocalSummons(bool enabled);
     bool localSummonsEnabled();
+    /** The same switch, by its real name: every RUNTIME ACTOR SPAWN on a client -- summons,
+     *  levelled-list creatures, PlaceAt/PlaceAtMe -- while a holder simulates the world. The
+     *  peer spawns them and registers each as a net object; the client would otherwise build
+     *  its own copy with a RefNum nobody else has: an AI-off statue next to the real one. */
+    inline void setLocalSpawns(bool enabled) { setLocalSummons(enabled); }
+    inline bool localSpawnsEnabled() { return localSummonsEnabled(); }
 }
 
 #endif

--- a/openmw/apps/openmw/mwscript/transformationextensions.cpp
+++ b/openmw/apps/openmw/mwscript/transformationextensions.cpp
@@ -1,3 +1,4 @@
+#include "../mwmp/puppets.hpp"
 #include <components/debug/debuglog.hpp>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
@@ -619,6 +620,10 @@ namespace MWScript
                 {
                     // create item
                     MWWorld::ManualRef ref(*MWBase::Environment::get().getESMStore(), itemID, 1);
+                    // Multiplayer client: a scripted ACTOR spawn is the peer's to make (it runs
+                    // the same script) and reaches us as a net object; a local one is a statue.
+                    if (ref.getPtr().getClass().isActor() && !MWMP::localSpawnsEnabled())
+                        continue;
                     ref.getPtr().mRef->mData.mPhysicsPostponed = !ref.getPtr().getClass().isActor();
 
                     MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->safePlaceObject(

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -333,7 +333,14 @@ end
 local function attachActorPuppets(cellKey)
     for _, obj in ipairs(cellActors(cellKey)) do
         local key = refKeyOf(obj)
-        if not puppetActors[key] then
+        -- A stale row (the object it named was removed -- a named runtime actor deleted, a
+        -- corpse disposed -- and the engine reused the slot) must not block the new actor.
+        local have = puppetActors[key]
+        if have then
+            local okv, same = pcall(function() return have.obj:isValid() and have.obj.id == obj.id end)
+            if not (okv and same) then have = nil end
+        end
+        if not have then
             local ok = pcall(function()
                 obj:addScript('scripts/mp/puppet.lua', { actorKey = key })
             end)

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -42,9 +42,44 @@ local batchesIn = 0 -- diagnostic: ActorMoveBatch frames applied as a non-holder
 -- --------------------------------------------------------------- ref helpers
 
 local function refKeyOf(obj)
-    -- content-file objects only (actors are never runtime-spawned): stable per session.
+    -- local key, stable per session. Runtime-spawned actors (levelled lists, PlaceAt,
+    -- summons) have no content RefNum: they are addressed on the wire by the net id the
+    -- server gave them (actorAddr), and resolved back with actorOf.
     return 'o:' .. obj.id
 end
+
+-- WIRE ADDRESS of an actor: content ref, or the net id of a runtime-spawned one. nil for a
+-- runtime actor the server has not named yet -- it must not travel until it can be resolved
+-- on the other side.
+local function actorAddr(obj)
+    local netId = deps and deps.netIdOf and deps.netIdOf(obj)
+    if netId then return { net = netId } end
+    if obj.contentFile then return { ref = obj } end
+    return nil
+end
+
+local function withAddr(body, obj)
+    local a = actorAddr(obj)
+    if not a then return nil end
+    body.ref = a.ref
+    body.net = a.net
+    return body
+end
+
+-- The actor a relayed body names, here: a content ref, or our copy of a net actor.
+local function actorOf(data)
+    if data.net ~= nil and deps and deps.objOfNet then
+        local obj = deps.objOfNet(data.net)
+        if obj and obj:isValid() then return obj end
+        return nil
+    end
+    local ref = data.ref
+    local ok, valid = pcall(function() return ref and ref:isValid() end)
+    return (ok and valid) and ref or nil
+end
+
+-- Runtime actors the holder has asked the server to name (netId pending).
+local netPending = {}
 
 local function cellKeyOf(cell)
     if not cell then return nil end
@@ -92,8 +127,10 @@ local function actorPose(obj)
         if stance == types.Actor.STANCE.Weapon then flags = flags + 16 end
         if stance == types.Actor.STANCE.Spell then flags = flags + 32 end
     end
+    local netId = deps and deps.netIdOf and deps.netIdOf(obj)
     return {
-        obj = obj,
+        obj = (not netId) and obj or nil,
+        net = netId,
         x = pos.x, y = pos.y, z = pos.z,
         yaw = obj.rotation:getYaw(),
         pitch = 0,
@@ -117,6 +154,20 @@ local function broadcastCell(cellKey, epoch, cell, now)
     -- fight. Cheap: a multiply per tracked (actor, player) pair, and only for actors in
     -- the cell we are simulating.
     threat.decay(now)
+    -- RUNTIME-SPAWNED ACTORS (levelled lists, PlaceAt, summons) exist on this engine only.
+    -- Ask the server to name each one; it becomes a net object every client builds from the
+    -- record (ObjectPlace with actor=true) and this stream addresses by net id. Until it is
+    -- named nothing about it travels -- nobody could resolve it -- so it is left out below.
+    local addressable = {}
+    for _, obj in ipairs(live) do
+        if obj.contentFile or (deps.netIdOf and deps.netIdOf(obj)) then
+            addressable[#addressable + 1] = obj
+        elseif not netPending[obj.id] and deps.requestNetActor then
+            netPending[obj.id] = true
+            deps.requestNetActor(obj, cellKey)
+        end
+    end
+    live = addressable
     for _, obj in ipairs(live) do
         local key = refKeyOf(obj)
         cell.actors[key] = cell.actors[key] or { deathNo = 0 }
@@ -146,7 +197,7 @@ local function broadcastCell(cellKey, epoch, cell, now)
                 tracked.statsFp = fp
                 tracked.nextStats = now + STATS_MIN_INTERVAL
                 mp.sendEvent('ActorStatsDynamic',
-                    { cellKey = cellKey, epoch = epoch, ref = obj, hp = dyn.hp, mp = dyn.mp, ft = dyn.ft })
+                    withAddr({ cellKey = cellKey, epoch = epoch, hp = dyn.hp, mp = dyn.mp, ft = dyn.ft }, obj))
             end
         end
 
@@ -173,7 +224,7 @@ local function broadcastCell(cellKey, epoch, cell, now)
                     tracked.equipFp = fp
                     tracked.nextEquip = now + EQUIP_MIN_INTERVAL
                     mp.sendEvent('ActorEquip',
-                        { cellKey = cellKey, epoch = epoch, ref = obj, slots = slots })
+                        withAddr({ cellKey = cellKey, epoch = epoch, slots = slots }, obj))
                 end
             end
         end
@@ -193,7 +244,7 @@ local function broadcastCell(cellKey, epoch, cell, now)
                     tracked.dispVal = disp
                     tracked.nextDisp = now + EQUIP_MIN_INTERVAL
                     mp.sendEvent('ActorDisposition',
-                        { cellKey = cellKey, epoch = epoch, ref = obj, disposition = disp })
+                        withAddr({ cellKey = cellKey, epoch = epoch, disposition = disp }, obj))
                 end
             end
         end
@@ -205,7 +256,8 @@ local function broadcastCell(cellKey, epoch, cell, now)
             mp.sendEvent('ActorDeath', {
                 cellKey = cellKey,
                 epoch = epoch,
-                ref = obj,
+                ref = actorAddr(obj) and actorAddr(obj).ref or nil,
+                net = actorAddr(obj) and actorAddr(obj).net or nil,
                 killerPlayerId = deps.ownIdFn(), -- holder attribution; nil-safe on the server
                 deathNo = tracked.deathNo,
                 killedRecordId = obj.recordId,
@@ -233,10 +285,11 @@ local function broadcastCell(cellKey, epoch, cell, now)
                 if toCell and toCell ~= cellKey and tracked.leftTo ~= toCell then
                     tracked.leftTo = toCell
                     local pos = obj.position
-                    mp.sendEvent('ActorCellChange', {
-                        cellKey = cellKey, epoch = epoch, ref = obj, toCellKey = toCell,
+                    local body = withAddr({
+                        cellKey = cellKey, epoch = epoch, toCellKey = toCell,
                         x = pos.x, y = pos.y, z = pos.z,
-                    })
+                    }, obj)
+                    if body then mp.sendEvent('ActorCellChange', body) end
                 end
             else
                 -- Gone entirely (unloaded or destroyed). Drop the row so a recycled key
@@ -257,13 +310,14 @@ local function snapshotCell(cellKey, epoch)
     local snapActors = {}
     for _, obj in ipairs(cellActors(cellKey)) do
         local dyn = dynSnapshot(obj)
-        snapActors[#snapActors + 1] = {
-            ref = obj,
+        local addr = actorAddr(obj)
+        if addr then snapActors[#snapActors + 1] = {
+            ref = addr.ref, net = addr.net,
             x = obj.position.x, y = obj.position.y, z = obj.position.z,
             rotZ = obj.rotation:getYaw(),
             hp = dyn.hp, mp = dyn.mp, ft = dyn.ft,
             dead = types.Actor.isDead(obj),
-        }
+        } end
     end
     mp.sendEvent('ActorSnapshot', { cellKey = cellKey, epoch = epoch, actors = snapActors })
 end
@@ -322,7 +376,7 @@ actors.handlers.MP_ActorAuthorityGrant = function(data)
     -- Apply the handoff snapshot: teleport actors to their last authoritative pose + stats.
     local snap = data.snapshot and data.snapshot.actors or {}
     for _, a in ipairs(snap) do
-        local obj = a.ref and a.ref:isValid() and a.ref or nil
+        local obj = actorOf(a)
         if obj then
             local cellArg = obj.cell and not obj.cell.isExterior and obj.cell.name or ''
             pcall(function()
@@ -379,7 +433,7 @@ actors.handlers.MP_ActorMoveBatch = function(batch)
     local now = core.getRealTime()
     batchesIn = batchesIn + 1
     for _, e in ipairs(batch) do
-        local obj = e.ref and e.ref:isValid() and e.ref or nil
+        local obj = actorOf(e)
         if obj and not types.Player.objectIsInstance(obj) then
             local key = refKeyOf(obj)
             if not puppetActors[key] then
@@ -400,7 +454,7 @@ end
 -- puppet stands where the pose stream stopped -- which is what left a travelling companion
 -- behind for everyone except the player who recruited them.
 actors.handlers.MP_ActorCellChange = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if not obj or type(data.toCellKey) ~= 'string' then return end
     local key = refKeyOf(obj)
     -- DETACH FIRST. The puppet script suppresses this actor's own AI, and it is keyed to the
@@ -423,7 +477,7 @@ actors.handlers.MP_ActorCellChange = function(data)
 end
 
 actors.handlers.MP_ActorStatsDynamic = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if obj and puppetActors[refKeyOf(obj)] then
         pcall(function() obj:sendEvent('MP_Stats', { hp = data.hp, mp = data.mp, ft = data.ft }) end)
     end
@@ -436,7 +490,7 @@ end
 -- disposition lives on the actor's own stats, and setBaseDisposition is a GLOBAL-context call
 -- (local scripts may only modify themselves), which is the context this handler runs in.
 actors.handlers.MP_ActorDisposition = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if not obj or type(data.disposition) ~= 'number' then return end
     local ownPlayer = world.players[1]
     if not (ownPlayer and ownPlayer:isValid()) then return end
@@ -474,10 +528,11 @@ function actors.noteFollow(obj, target, escort)
         claimedFollow[key] = (followId ~= nil) or nil
         epoch = epoch or 0 -- a claim is not epoch-checked; the field only has to be present
     end
-    mp.sendEvent('ActorAI', {
-        cellKey = cellKey, epoch = epoch, ref = obj, follow = followId,
+    local body = withAddr({
+        cellKey = cellKey, epoch = epoch, follow = followId,
         escort = (followId ~= nil and type(escort) == 'table') and escort or nil,
-    })
+    }, obj)
+    if body then mp.sendEvent('ActorAI', body) end
 end
 
 -- PERSUASION, the sending half. Called by quests.lua when a conversation ends and the NPC's
@@ -487,10 +542,11 @@ function actors.noteDisposition(obj, disposition)
     if not (obj and obj:isValid()) or type(disposition) ~= 'number' then return end
     local cellKey = actors.cellKeyOfObj(obj)
     if not cellKey then return end
-    mp.sendEvent('ActorDisposition', {
-        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj,
+    local body = withAddr({
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0,
         disposition = math.max(0, math.min(100, math.floor(disposition + 0.5))),
-    })
+    }, obj)
+    if body then mp.sendEvent('ActorDisposition', body) end
 end
 
 -- COMBAT STATE, the sending half. Holder-only (the holder is where the fight is real): who
@@ -509,9 +565,10 @@ function actors.noteCombat(obj, target)
         local own = deps.ownIdFn and deps.ownIdFn() or nil
         if foeId == nil or foeId ~= own then return end
     end
-    mp.sendEvent('ActorAI', {
-        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj, combat = foeId or false,
-    })
+    local body = withAddr({
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, combat = foeId or false,
+    }, obj)
+    if body then mp.sendEvent('ActorAI', body) end
 end
 
 -- SCRIPTED TRAVEL. "AITravel x y z" from a dialogue result stacks Travel on the talking
@@ -523,10 +580,11 @@ function actors.noteTravel(obj, dest)
     if not (obj and obj:isValid()) or type(dest) ~= 'table' or type(dest.x) ~= 'number' then return end
     local cellKey = actors.cellKeyOfObj(obj)
     if not cellKey then return end
-    mp.sendEvent('ActorAI', {
-        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0, ref = obj,
+    local body = withAddr({
+        cellKey = cellKey, epoch = actors.epochOf(cellKey) or 0,
         travel = { x = dest.x, y = dest.y or 0, z = dest.z or 0 },
-    })
+    }, obj)
+    if body then mp.sendEvent('ActorAI', body) end
 end
 
 local function aimAt(obj, target, escort)
@@ -577,7 +635,7 @@ function actors.forgetFollowers(playerId)
 end
 
 actors.handlers.MP_ActorAI = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if not obj then return end
     if type(data.travel) == 'table' and type(data.travel.x) == 'number' then
         -- A scripted destination. On a puppet (AI off) it is state only; on the holder the
@@ -618,7 +676,7 @@ actors.handlers.MP_ActorAI = function(data)
 end
 
 actors.handlers.MP_ActorEquip = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if obj and puppetActors[refKeyOf(obj)] then
         pcall(function() obj:sendEvent('MP_Equip', { slots = data.slots or {} }) end)
     end
@@ -629,9 +687,8 @@ end
 -- payday, and without this an infinite-respawn world mints artifacts forever. Applied by
 -- every client in the cell (an event, not a per-player view), so nobody can decline it.
 actors.handlers.MP_ActorStripLoot = function(data)
-    local obj = data.ref
-    local okValid, valid = pcall(function() return obj:isValid() end)
-    if not (okValid and valid) then return end
+    local obj = actorOf(data)
+    if not obj then return end
     pcall(function()
         for _, item in ipairs(types.Actor.inventory(obj):getAll()) do
             if item:isValid() then item:remove() end
@@ -640,7 +697,7 @@ actors.handlers.MP_ActorStripLoot = function(data)
 end
 
 actors.handlers.MP_ActorDeath = function(data)
-    local obj = data.ref and data.ref:isValid() and data.ref or nil
+    local obj = actorOf(data)
     if obj and puppetActors[refKeyOf(obj)] then
         pcall(function() obj:sendEvent('MP_Kill', {}) end)
     end
@@ -711,6 +768,12 @@ end
 -- Phase 4C: does ANYONE simulate this cell right now (the peer, in the one-peer model)?
 -- Distinct from isHolderOf ("do I"). combat.lua asks this to decide whether a real melee
 -- hit is forwarded (nobody simulating: degraded relay) or left to the avatar's own swing.
+-- Does ANY cell we know of have a simulator? The first ActorAuthorityInfo of a session says
+-- "this world is peer-simulated"; used to keep local runtime spawns off from then on.
+function actors.anyHolder()
+    return next(held) ~= nil or next(holderOfCell) ~= nil
+end
+
 function actors.hasHolder(cellKey)
     return cellKey ~= nil and (held[cellKey] ~= nil or holderOfCell[cellKey] ~= nil)
 end

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -174,6 +174,7 @@ local function broadcastCell(cellKey, epoch, cell, now)
         local tracked = cell.actors[key]
         tracked.obj = obj
         tracked.seen = now
+        tracked.netId = deps.netIdOf and deps.netIdOf(obj) or nil
 
         -- Sticky aggro: retarget only when a challenger clears the margin, which is what
         -- stops the enemy strobing between two players and hitting neither.
@@ -293,7 +294,12 @@ local function broadcastCell(cellKey, epoch, cell, now)
                 end
             else
                 -- Gone entirely (unloaded or destroyed). Drop the row so a recycled key
-                -- cannot inherit a stale leftTo and swallow a later, real move.
+                -- cannot inherit a stale leftTo and swallow a later, real move. A NAMED
+                -- runtime actor that is gone here (a script's Disable/SetDelete, a summon
+                -- expiring) is gone everywhere: every client holds a copy built from our word.
+                if tracked.netId then
+                    mp.sendEvent('ObjectDelete', { net = tracked.netId, cellKey = cellKey })
+                end
                 cell.actors[key] = nil
             end
         else

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -815,11 +815,15 @@ end
 -- Re-evaluated as the holder comes and goes; degraded mode (no peer) keeps local summons.
 local localSummonsOn = true
 local function localSummonsTick()
-    if (mp.isSystem and mp.isSystem()) or not mp.setLocalSummons then return end
-    local want = not actors.hasHolder(ownCellKeyCache)
+    if (mp.isSystem and mp.isSystem()) or not (mp.setLocalSpawns or mp.setLocalSummons) then return end
+    -- STICKY on "this world is simulated": levelled lists roll at cell load, before the new
+    -- cell's ActorAuthorityInfo arrives, so gating on our own cell alone would roll a local
+    -- creature in every cell we enter and then learn better. Once any holder has been seen the
+    -- peer is the one spawning; only a peer outage (every holder gone) hands it back to us.
+    local want = not (actors.hasHolder(ownCellKeyCache) or actors.anyHolder())
     if want ~= localSummonsOn then
         localSummonsOn = want
-        pcall(mp.setLocalSummons, want)
+        pcall(mp.setLocalSpawns or mp.setLocalSummons, want)
     end
 end
 
@@ -1255,6 +1259,11 @@ local function start()
     -- it never double-drives or broadcasts them as cell NPCs.
     actors.init({
         playerFn = playerScript,
+        -- Runtime-spawned actors: named by the server through the object-sync path, addressed
+        -- by net id on the actor stream (actors.lua actorAddr / actorOf).
+        netIdOf = objects.netIdOf,
+        objOfNet = objects.objOfNet,
+        requestNetActor = function(obj, cellKey) objects.requestSpawn(obj, nil, cellKey, false, true) end,
         ownCellKeyFn = function() return ownCellKeyCache end,
         ownIdFn = function() return net.state == 'Joined' and net.playerId or nil end,
         isMpPuppetFn = function(obj)

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -820,7 +820,8 @@ local function localSummonsTick()
     -- cell's ActorAuthorityInfo arrives, so gating on our own cell alone would roll a local
     -- creature in every cell we enter and then learn better. Once any holder has been seen the
     -- peer is the one spawning; only a peer outage (every holder gone) hands it back to us.
-    local want = not (actors.hasHolder(ownCellKeyCache) or actors.anyHolder())
+    local simulated = net.state == 'Joined' and net.flags and net.flags.simulated == true
+    local want = not (simulated or actors.hasHolder(ownCellKeyCache) or actors.anyHolder())
     if want ~= localSummonsOn then
         localSummonsOn = want
         pcall(mp.setLocalSpawns or mp.setLocalSummons, want)

--- a/openmw/files/data/scripts/mp/objects.lua
+++ b/openmw/files/data/scripts/mp/objects.lua
@@ -549,7 +549,7 @@ end
 -- to being PLACED by a script or tool. The server can only apply "you cannot drop what you
 -- do not have" to the former — ObjectSpawnRequest is the generic place-an-object op, and
 -- refusing everything unowned wrongly blocked scripted containers nobody carries.
-function objects.requestSpawn(obj, posOverride, cellKeyOverride, fromInventory)
+function objects.requestSpawn(obj, posOverride, cellKeyOverride, fromInventory, actor)
     tempCounter = tempCounter + 1
     pendingSpawns[tempCounter] = obj
     local pos = posOverride or obj.position
@@ -567,6 +567,9 @@ function objects.requestSpawn(obj, posOverride, cellKeyOverride, fromInventory)
         rotZ = rotZ,
         count = math.max(obj.count or 1, 1), -- unplaced objects report count 0; server needs >=1
         fromInventory = fromInventory == true,
+        -- The holder naming a runtime-spawned NPC/creature (actors.lua): every client builds
+        -- it from the record and puppets it; the actor stream then addresses it by net id.
+        actor = actor == true or nil,
     })
 end
 
@@ -591,6 +594,12 @@ end
 handlers.MP_ObjectSpawnRefused = function(data)
     local obj = data and pendingSpawns[data.tempId]
     if data and data.tempId ~= nil then pendingSpawns[data.tempId] = nil end
+    if obj and obj:isValid() and types.Actor.objectIsInstance(obj) then
+        -- The holder's naming of a runtime actor was refused (a full cell): it stays a local
+        -- creature nobody else sees, which is the pre-2026-09-11 state, not an item to pocket.
+        print('[mp] net actor naming refused: ' .. tostring(data and data.reason))
+        return
+    end
     local player = deps.playerFn()
     if obj and obj:isValid() and player then
         pcall(function() obj:moveInto(types.Actor.inventory(player)) end)
@@ -612,6 +621,27 @@ handlers.MP_ObjectPlace = function(data)
     -- dynamic id, which could collide with an unrelated local record here.
     local recordId = worldmp.toLocal(data.recordId)
     local ok, obj = pcall(function() return world.createObject(recordId, data.count or 1) end)
+    if data.actor then
+        -- A runtime-spawned NPC/creature the holder named. Built from the record here and
+        -- puppeted by the non-holder sweep like any other actor in the cell; no stand-in --
+        -- a wrong body computes nothing, it just is not there.
+        if not (ok and types.Actor.objectIsInstance(obj)) then
+            if ok then pcall(function() obj:remove() end) end
+            print('[mp] net actor unresolvable: ' .. tostring(data.recordId))
+            return
+        end
+        local cellArg = data.cellKey and (data.cellKey:match('^%-?%d+,%-?%d+$') and '' or data.cellKey)
+        if not cellArg then
+            local player = deps.playerFn()
+            cellArg = (player and player.cell and not player.cell.isExterior) and player.cell.name or ''
+        end
+        pcall(function() obj:teleport(cellArg, util.vector3(data.x, data.y, data.z),
+            { rotation = util.transform.rotateZ(data.rotZ or 0) }) end)
+        netToObj[data.netId] = obj
+        objIdToNet[obj.id] = data.netId
+        netSpawned[obj.id] = true
+        return
+    end
     -- Foreign dynamic record ids can COLLIDE with unrelated local dynamic records (each
     -- client numbers its own "$dynamic" records — B's may be a puppet NPC record!): only
     -- accept a resolution that is actually an item; anything else gets the stand-in.

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -78,7 +78,8 @@ known and recorded; N/A = does not exist in single player either.
 |---|---|---|
 | Pick up / two players race | ObjectTakeRequest first-wins, tombstone, refusal shown | OK |
 | Drop | ObjectSpawn, netId, refused reasons incl. cell_full | FIXED 09-10 (no cell_full line) |
-| Containers, merchants' stock and gold | canonical on first open; gold deltas; 24 h restock | OK |
+| Containers, merchants' stock and gold | canonical on first open; gold deltas; 24 h gold restock; item restock from `origin` on cell reset | OK |
+| Levelled item lists (containers, world) | container contents canonical on first open; a world-placed levelled item ref rolls per engine (rare, cosmetic) | OK |
 | Item condition / charge / soul | per-field merge: charge client, condition raise client, soul peer | FIXED 09-11 |
 | Repair / recharge / soul trap | see above | FIXED 09-11 |
 | Quest items never deplete | container rule | OK |
@@ -101,6 +102,7 @@ known and recorded; N/A = does not exist in single player either.
 | Taunt -> fight; resist arrest -> fight | lock holder claims combat; holder starts it | FIXED 09-11 |
 | Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors | FIXED 09-10/11 |
 | Dialogue-started AiTravel | companion.lua reports; lock holder claim | FIXED 09-11 |
+| Dialogue-started AiWander / AiActivate | not relayed; the holder's copy keeps its own package (cosmetic: an NPC told to stand still by a dialogue keeps wandering elsewhere) | OK (cosmetic) |
 | Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11 |
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |
 | Death, loot, corpse | ActorDeath, corpse container canonical | OK |

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -120,6 +120,10 @@ known and recorded; N/A = does not exist in single player either.
 | OnDeath / GetDeadCount | shared tally | OK |
 | Scripted PlaceAt / PositionCell of NPCs | see runtime-spawned actors | GAP |
 | Scripted AddItem/RemoveItem on NPCs | runs on every engine identically (deterministic) | OK (by construction) |
+| Scripted Disable/SetDelete of a named runtime actor | holder sees it gone -> ObjectDelete by net id; holder loss purges the cell's named actors | FIXED 09-11 |
+| Scripted PositionCell/SetPos of an NPC | runs on every engine; holder's poses/ActorCellChange win | OK |
+| ForceGreeting | client-side dialogue, no lock taken | OK (two players may both be forced; harmless) |
+| Companion share (follower inventory) | actor inventory as a container: ContainerOp canonical, relayed to the holder | OK |
 | StartScript/StopScript | runs per engine; globals reconcile | OK |
 
 ## 8. World

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -105,7 +105,7 @@ known and recorded; N/A = does not exist in single player either.
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |
 | Death, loot, corpse | ActorDeath, corpse container canonical | OK |
 | Content-placed NPCs/creatures | content RefNum, addressable everywhere | OK |
-| **Runtime-spawned actors** (levelled-list creatures, PlaceAtPC/PlaceAtMe, script spawns) | per-engine dynamic RefNums: the peer's creature and the client's are different objects; clients show AI-off statues, the peer's copy fights avatars unseen | **GAP — in progress** (net-actor sync) |
+| Runtime-spawned actors (levelled-list creatures, PlaceAtPC/PlaceAtMe, script spawns) | the holder names each one through the object-sync path (actor=true); clients build it from the record and puppet it; the actor stream and events address it by net id (contentFile -2 on the wire); clients suppress their own rolls/spawns once any holder is known | FIXED 09-11 (engine + protocol; needs a native-peer scenario to prove end to end) |
 | Replayed one-shot quest encounters | spawned on the peer beside the avatar | FIXED 09-11 |
 
 ## 7. Quests and scripts

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -415,7 +415,30 @@ export class WorldState {
   }
 
   authorityLeave(playerId: number, cellKey: string, connected: boolean): void {
-    this.enqueue(() => this.authority.onLeave(playerId, cellKey, connected));
+    this.enqueue(async () => {
+      await this.authority.onLeave(playerId, cellKey, connected);
+      // NAMED RUNTIME ACTORS DIE WITH THEIR HOLDER. A levelled-list creature the peer named
+      // exists on the peer's engine; when the peer leaves the cell or restarts, nothing
+      // simulates it, and the next holder rolls and names its own. Left in the doc they
+      // would pile up, one generation per restart, as statues on every client.
+      if (this.authority.holderOf(cellKey) === undefined) await this.purgeNamedActors(cellKey);
+    });
+  }
+
+  private async purgeNamedActors(cellKey: string): Promise<void> {
+    const doc = await this.cells.get(cellKey);
+    let n = 0;
+    for (const [key, p] of Object.entries(doc.placed)) {
+      if ((p as { actor?: boolean }).actor !== true) continue;
+      delete doc.placed[key];
+      delete doc.moved[key];
+      n++;
+      this.relayCell(cellKey, 'ObjectDelete', { net: p.netId, cellKey, byId: 0 });
+    }
+    if (n > 0) {
+      this.cells.markDirty(cellKey);
+      log('info', 'world.named_actors_purged', { cellKey, n });
+    }
   }
 
   // Validates {cellKey, epoch} against the current authority for the sender's cell.

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -424,7 +424,8 @@ export class WorldState {
     const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
     const epoch = finite(body.get('epoch'));
     const ref = parseObjRef(body);
-    if (!cellKey || epoch === undefined || !ref || ref.kind !== 'ref') {
+    // Content refs, or the net id of a runtime-spawned actor the holder named (spawn()).
+    if (!cellKey || epoch === undefined || !ref) {
       this.invalid(player, name);
       return undefined;
     }
@@ -719,6 +720,9 @@ export class WorldState {
     // "put an object in the world", which scripts and tools use for things nobody carries
     // (s31 spawns a chest) — so conservation could only ever be counted, never enforced.
     const fromInventory = body.get('fromInventory') === true;
+    // The holder naming a runtime-spawned actor owns nothing of the kind and is not dropping
+    // anything: the ownership ledger does not apply (and would flag the peer's account).
+    const actor = body.get('actor') === true && player.system === true;
     // COUNTED, NOT REFUSED — and that is a measured decision, not caution.
     //
     // Refusing unowned spawns in the shared world was implemented and then backed out: this
@@ -738,7 +742,7 @@ export class WorldState {
     // so the Lua suite discovers these reasons and holds the client to wording each of them.
     const reply = (ok: boolean, reason: string) =>
       player.peer.sendEvent('ObjectSpawnRefused', { tempId, ok, reason });
-    const held = this.heldCount?.(player, recordId);
+    const held = actor ? undefined : this.heldCount?.(player, recordId);
     if (held !== undefined && held < count) {
       metrics.unownedDrops.inc();
       this.moderationNote?.(player.accountKey, 'unowned_drop');
@@ -788,8 +792,11 @@ export class WorldState {
       return;
     }
     if (fromInventory) this.debitAcquired?.(player, recordId, count);
+    // A runtime-spawned ACTOR the holder is naming (levelled-list creature, script spawn).
+    // Holder-only by construction: a client's actor placement would be a body it can then
+    // steer nowhere; the flag is carried so every client builds an actor, not an item.
     const netId = this.cells.allocNetId();
-    const placed = { netId, recordId, cellKey, x, y, z, rotZ, count, byId: player.id };
+    const placed = { netId, recordId, cellKey, x, y, z, rotZ, count, byId: player.id, ...(actor ? { actor: true } : {}) };
     doc.placed[netRefKey(netId)] = placed;
     this.cells.markDirty(cellKey);
     // Ack first: the requester is in the cell-scoped broadcast set, and per-connection

--- a/server/src/net/connection.ts
+++ b/server/src/net/connection.ts
@@ -1690,6 +1690,7 @@ export class Connection implements Peer {
         lodNearRadius: this.ctx.config.limits.lodNearRadius,
         lodMidRadius: this.ctx.config.limits.lodMidRadius,
         lodNearMaxAvatars: this.ctx.config.limits.lodNearMaxAvatars,
+        simulated: this.ctx.config.simPeer.enabled || this.ctx.worldPeer() !== undefined,
       },
       (account.characters ?? []).map(({ id, name, lastPlayedAt }) => ({ id, name, lastPlayedAt })),
       char?.id ?? '',

--- a/server/src/proto/session.ts
+++ b/server/src/proto/session.ts
@@ -255,6 +255,11 @@ export interface SessionFlags {
   lodNearRadius: number;
   lodMidRadius: number;
   lodNearMaxAvatars: number; // hard ceiling on fully-simulated avatars; 0 = radius only
+  // A sim peer simulates this world: the client must not roll its own levelled-list
+  // creatures or script-spawned actors (they arrive as named net objects from the holder).
+  // Known at join, before the first cell's authority info -- which is after the first
+  // cell's lists have already rolled.
+  simulated?: boolean;
 }
 
 // Character slots: what the client's select UI needs — never the whole doc.

--- a/server/test/actor.test.ts
+++ b/server/test/actor.test.ts
@@ -186,6 +186,31 @@ test('actor authority and relay end to end', async (t) => {
     await a.waitEvent('PlayerLeaveWorld'); // free her per-IP connection slot before the next test connects
   });
 
+  // RUNTIME-SPAWNED ACTORS. A levelled-list creature or a script spawn exists on the holder's
+  // engine only, with a RefNum nobody else shares. The holder names it through the object-sync
+  // path (actor=true), every client builds it from the record, and the actor family may then
+  // address it by net id. A CLIENT naming an actor is just an item placement (flag dropped).
+  await t.test('the holder names a runtime actor; actor events then address it by net id', async () => {
+    b.inbox.events.length = 0;
+    a.sendEvent('ObjectSpawnRequest', { tempId: 501, recordId: 'cliff racer', cellKey: '0,0', x: 10, y: 20, z: 30, rotZ: 0, count: 1, actor: true });
+    const ack = await a.waitEvent('ObjectSpawnAck', (v) => (v as { tempId?: number }).tempId === 501);
+    const netId = (ack.value as { netId: number }).netId;
+    const placed = await b.waitEvent('ObjectPlace', (v) => (v as { netId?: number }).netId === netId);
+    assert.equal((placed.value as { actor?: boolean }).actor, true, 'clients are told to build an actor, not an item');
+    assert.equal((placed.value as { recordId?: string }).recordId, 'cliff racer');
+
+    b.inbox.events.length = 0;
+    a.sendEvent('ActorStatsDynamic', { cellKey: '0,0', epoch: epochA, net: netId, hp: { c: 5, b: 50 }, mp: { c: 0, b: 0 }, ft: { c: 9, b: 90 } });
+    const st = await b.waitEvent('ActorStatsDynamic');
+    assert.equal((st.value as { net?: number }).net, netId, 'a net-addressed actor event relays with its net id');
+
+    // A client's "actor" placement is an ordinary item placement: the flag does not survive.
+    a.inbox.events.length = 0;
+    b.sendEvent('ObjectSpawnRequest', { tempId: 502, recordId: 'gold_001', cellKey: '0,0', x: 1, y: 2, z: 3, rotZ: 0, count: 1, actor: true });
+    const forged = await a.waitEvent('ObjectPlace', (v) => (v as { recordId?: string }).recordId === 'gold_001');
+    assert.equal((forged.value as { actor?: boolean }).actor, undefined, 'a client made every screen build an actor');
+  });
+
   await t.test('far player receives no actor traffic', async () => {
     const c = await TestClient.connect(server.port);
     await c.joinAsNew('Cara');


### PR DESCRIPTION
Runtime-spawned actors (levelled-list creatures, PlaceAt, summons) have per-engine RefNums; the peer's copy and the client's were different objects and nothing could name one to the other. The holder now names each through the object-sync path (`actor=true`), clients build it from the record and puppet it, and the actor family addresses it by net id (contentFile −2 on the binary stream). Clients suppress their own rolls once any holder is known. Server honours the flag from the peer only; authCheck accepts net refs. Test added; tsc clean; Lua runner 90/90; native peer compile + full suite running before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)