### PR TITLE
The peer named its own despawning avatar as a runtime actor

### DIFF
--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -162,7 +162,13 @@ local function broadcastCell(cellKey, epoch, cell, now)
     for _, obj in ipairs(live) do
         if obj.contentFile or (deps.netIdOf and deps.netIdOf(obj)) then
             addressable[#addressable + 1] = obj
-        elseif not netPending[obj.id] and deps.requestNetActor then
+        elseif not netPending[obj.id] and deps.requestNetActor
+            -- CONTENT RECORDS ONLY. A levelled creature, a script spawn, a summon: all bodies
+            -- built from a record everyone has. A "Generated:" record is a puppet or avatar
+            -- body this engine minted -- seen here for one tick between despawnPuppet
+            -- forgetting it and the engine removing it -- and naming it made every client
+            -- try to build an actor from a record only this process knows.
+            and not tostring(obj.recordId):lower():match('^generated:') then
             netPending[obj.id] = true
             deps.requestNetActor(obj, cellKey)
         end

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -107,7 +107,7 @@ known and recorded; N/A = does not exist in single player either.
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |
 | Death, loot, corpse | ActorDeath, corpse container canonical | OK |
 | Content-placed NPCs/creatures | content RefNum, addressable everywhere | OK |
-| Runtime-spawned actors (levelled-list creatures, PlaceAtPC/PlaceAtMe, script spawns) | the holder names each one through the object-sync path (actor=true); clients build it from the record and puppet it; the actor stream and events address it by net id (contentFile -2 on the wire); clients suppress their own rolls/spawns once any holder is known | FIXED 09-11 (engine + protocol; needs a native-peer scenario to prove end to end) |
+| Runtime-spawned actors (levelled-list creatures, PlaceAtPC/PlaceAtMe, script spawns) | the holder names each one through the object-sync path (actor=true); clients build it from the record and puppet it; the actor stream and events address it by net id (contentFile -2 on the wire); clients suppress their own rolls/spawns once any holder is known | FIXED 09-11 (engine + protocol). Live: the native peer against retail data named `scrib`, `kwama forager`, `scrib` in `-2,-7` within 60 ms of its grant, no drops; the client half (build from record, resolve by net id) is covered by actor.test.ts and the Lua runner, and owes a browser scenario |
 | Replayed one-shot quest encounters | spawned on the peer beside the avatar | FIXED 09-11 |
 
 ## 7. Quests and scripts


### PR DESCRIPTION
Found by running the native peer against retail data locally: when a player left, the avatar body was seen for one tick as an unknown runtime actor and named (`Generated:0x10` placed in the cell doc). Only content-record actors are named now. Same run proved the naming path end to end: three levelled creatures named in `-2,-7` within 60 ms of the grant, no drops or invalids. Lua runner 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)