### PR TITLE
A script-placed quest NPC could not be talked to, recruited, taunted or sent walking

### DIFF
--- a/openmw/files/data/scripts/mp/combat.lua
+++ b/openmw/files/data/scripts/mp/combat.lua
@@ -78,7 +78,8 @@ function combat.onPuppetHit(data)
         -- nothing. Send it and let the server decide; it is the one holding the authority
         -- table, and quoting a stale epoch is the only thing it actually needs protecting from.
         local epoch = deps.epochOf(cellKey)
-        target = { ref = data.victim, cellKey = cellKey }
+        local netId = deps.netIdOf and deps.netIdOf(data.victim)
+        target = { ref = (not netId) and data.victim or nil, net = netId, cellKey = cellKey }
         if epoch then target.epoch = epoch end
     else
         return
@@ -112,7 +113,8 @@ function combat.onPuppetSpellHit(data)
     elseif data.victim and data.victim:isValid() then
         local cellKey = deps.cellKeyOfObj(data.victim)
         if not cellKey then note('no-cell') return end
-        target = { ref = data.victim, cellKey = cellKey }
+        local netId = deps.netIdOf and deps.netIdOf(data.victim)
+        target = { ref = (not netId) and data.victim or nil, net = netId, cellKey = cellKey }
         local epoch = deps.epochOf(cellKey)
         if epoch then target.epoch = epoch end
     else
@@ -172,6 +174,7 @@ local function resolveVictim(data)
         return target.playerId == deps.ownIdFn() and deps.playerFn() or nil
     end
     local obj = target.ref
+    if target.net ~= nil and deps.objOfNet then obj = deps.objOfNet(target.net) end
     if obj and obj:isValid() and deps.isHolderOf(deps.cellKeyOfObj(obj)) then
         return obj
     end
@@ -185,6 +188,7 @@ combat.handlers = {}
 -- does the hitting and they are ignored entirely.
 local function creditThreat(data)
     local ref = data.ref
+    if data.net ~= nil and deps.objOfNet then ref = deps.objOfNet(data.net) end
     local ok, valid = pcall(function() return ref and ref:isValid() end)
     if not (ok and valid) then return end
     local dmg = (data.damage and data.damage.health) or 0

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1336,6 +1336,7 @@ local function start()
     quests.init({
         playerFn = playerScript,
         dispositionOutFn = function(obj, d) actors.noteDisposition(obj, d) end,
+        netIdOf = objects.netIdOf, -- a script-placed quest NPC is a net actor; lock it like any other
         ownCellKeyFn = function() return ownCellKeyCache end,
         ownIdFn = function() return net.state == 'Joined' and net.playerId or nil end,
         noticeFn = notice,

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1327,6 +1327,9 @@ local function start()
         isHolderOf = actors.isHolderOf,
         hasHolder = actors.hasHolder,
         cellKeyOfObj = actors.cellKeyOfObj,
+        -- A runtime actor the holder named is addressed by its net id (actors.lua actorAddr).
+        netIdOf = objects.netIdOf,
+        objOfNet = objects.objOfNet,
         -- PvP is a server rule (SessionWelcome.flags.pvp); default OFF until told otherwise.
         isPvpEnabled = function() return net.flags and net.flags.pvp == true end,
     })
@@ -1337,6 +1340,7 @@ local function start()
         playerFn = playerScript,
         dispositionOutFn = function(obj, d) actors.noteDisposition(obj, d) end,
         netIdOf = objects.netIdOf, -- a script-placed quest NPC is a net actor; lock it like any other
+        objOfNet = objects.objOfNet,
         ownCellKeyFn = function() return ownCellKeyCache end,
         ownIdFn = function() return net.state == 'Joined' and net.playerId or nil end,
         noticeFn = notice,

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -498,7 +498,16 @@ local function applyPhase2(record)
         local dyn = stats.dynamic
         if dyn then
             local d = Actor.stats.dynamic
-            if dyn.hp then d.health(self).base = dyn.hp.b; d.health(self).current = dyn.hp.c end
+            if dyn.hp then
+                -- NEVER RESTORE A CORPSE. Death is a flush point, so a player who died and
+                -- closed the tab has hp 0 on record. Writing 0 onto the live player kills
+                -- them on arrival, the death edge fires again (wasDead was reset), the world
+                -- hears "X has fallen" a second time and the respawn plugin runs again --
+                -- at the spot they died, so a bad spot became a loop across rejoins. They
+                -- already paid for that death. Back at a sliver of health, where they fell.
+                d.health(self).base = dyn.hp.b
+                d.health(self).current = (dyn.hp.c > 0) and dyn.hp.c or math.max(1, math.floor(dyn.hp.b * 0.1))
+            end
             if dyn.mp then d.magicka(self).base = dyn.mp.b; d.magicka(self).current = dyn.mp.c end
             if dyn.ft then d.fatigue(self).base = dyn.ft.b; d.fatigue(self).current = dyn.ft.c end
         end

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -595,6 +595,7 @@ end
 handlers.MP_MemberVarUpdate = function(data)
     if type(data.name) ~= 'string' or type(data.value) ~= 'number' then return end
     local obj = data.ref
+    if data.net ~= nil and deps.objOfNet then obj = deps.objOfNet(data.net) end
     local okValid, valid = pcall(function() return obj:isValid() end)
     if not (okValid and valid) then return end
     local script = world.mwscript.getLocalScript(obj)
@@ -707,6 +708,8 @@ end
 
 handlers.MP_DialogueLockResult = function(data)
     local obj = data.ref
+    -- A net-addressed NPC comes back as its net id (quests.ts refBody), not a GObject.
+    if type(obj) == 'number' and deps.objOfNet then obj = deps.objOfNet(obj) end
     local okValid, valid = pcall(function() return obj:isValid() end)
     if not (okValid and valid) then return end
     if not lockPending or lockPending.id ~= obj.id then

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -430,10 +430,21 @@ local function mirrorLock(state)
     mp.set('dialogueLock', json.encode(state))
 end
 
+-- Wire address of an NPC: its content ref, or the net id of a runtime actor the holder named
+-- (a quest NPC placed by a script). Nil for a body nobody else can resolve.
+local function npcAddr(obj)
+    local netId = deps.netIdOf and deps.netIdOf(obj)
+    if netId then return { net = netId } end
+    if obj.contentFile then return { ref = obj } end
+    return nil
+end
+
 local function requestLock(obj)
     lockPending = obj
+    local a = npcAddr(obj)
+    if not a then return end
     mp.sendEvent('DialogueLock', {
-        ref = obj, cellKey = deps.ownCellKeyFn(), want = true,
+        ref = a.ref, net = a.net, cellKey = deps.ownCellKeyFn(), want = true,
     })
 end
 
@@ -458,7 +469,8 @@ function quests.releaseLock(why)
         end
     end
     lockDisposition = nil
-    mp.sendEvent('DialogueLock', { ref = obj, cellKey = deps.ownCellKeyFn(), want = false })
+    local a = npcAddr(obj)
+    if a then mp.sendEvent('DialogueLock', { ref = a.ref, net = a.net, cellKey = deps.ownCellKeyFn(), want = false }) end
     mirrorLock({ ref = obj:isValid() and obj.recordId or '?', granted = false, why = why or 'released' })
 end
 
@@ -468,7 +480,7 @@ function quests.onNpcActivate(obj, actor)
     local player = playerObj()
     if not player or not actor or actor.id ~= player.id then return end
     if deps.isMpPuppetFn and deps.isMpPuppetFn(obj) then return end -- remote players aren't NPCs to lock
-    if not obj.contentFile then return end -- no portable ref: cannot be arbitrated
+    if not npcAddr(obj) then return end -- no portable ref: cannot be arbitrated
     if lockAllowOnce == obj.id then
         lockAllowOnce = nil
         return -- granted: let the engine open the dialogue window

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -29,6 +29,16 @@ local quests = {}
 --                                  rosterNameFn, isMpPuppetFn}
 local deps = nil
 
+-- Wire address of an NPC: its content ref, or the net id of a runtime actor the holder named
+-- (a quest NPC placed by a script). Nil for a body nobody else can resolve.
+local function npcAddr(obj)
+    local netId = deps.netIdOf and deps.netIdOf(obj)
+    if netId then return { net = netId } end
+    if obj.contentFile then return { ref = obj } end
+    return nil
+end
+
+
 local DIFF_INTERVAL = 1.0 -- globals / factions / crime poll (PROTOCOL.md §M6: 1 s diff)
 local MEMBER_WATCH_SECONDS = 6 -- MemberVarUpdate piggybacks on an interaction window
 local MEMBER_POLL = 0.25
@@ -410,7 +420,8 @@ local function tickMemberVars(now)
                 if watch.last[name] ~= value then
                     watch.last[name] = value
                     -- No cellKey in the body: the server infers it from our current cell.
-                    mp.sendEvent('MemberVarUpdate', { ref = watch.obj, name = name, value = value })
+                    local a = npcAddr(watch.obj)
+                    if a then mp.sendEvent('MemberVarUpdate', { ref = a.ref, net = a.net, name = name, value = value }) end
                 end
             end
         end
@@ -428,15 +439,6 @@ end
 local function mirrorLock(state)
     lastLockMirror = state
     mp.set('dialogueLock', json.encode(state))
-end
-
--- Wire address of an NPC: its content ref, or the net id of a runtime actor the holder named
--- (a quest NPC placed by a script). Nil for a body nobody else can resolve.
-local function npcAddr(obj)
-    local netId = deps.netIdOf and deps.netIdOf(obj)
-    if netId then return { net = netId } end
-    if obj.contentFile then return { ref = obj } end
-    return nil
 end
 
 local function requestLock(obj)

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -77,6 +77,7 @@ known and recorded; N/A = does not exist in single player either.
 | Action | MP path | Status |
 |---|---|---|
 | Pick up / two players race | ObjectTakeRequest first-wins, tombstone, refusal shown | OK |
+| Loot in the last 2 s before a disconnect/kick | inventory snapshot is 2 s diffed; the acquisition ledger is a timing hint, not state; the rejoin restore never confiscates surplus, so the client's local copy wins on rejoin | OK (bounded loss window ≤ 2 s, by design) |
 | Drop | ObjectSpawn, netId, refused reasons incl. cell_full | FIXED 09-10 (no cell_full line) |
 | Containers, merchants' stock and gold | canonical on first open; gold deltas; 24 h gold restock; item restock from `origin` on cell reset | OK |
 | Levelled item lists (containers, world) | container contents canonical on first open; a world-placed levelled item ref rolls per engine (rare, cosmetic) | OK |

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -20,6 +20,7 @@ known and recorded; N/A = does not exist in single player either.
 | Sign in (password / SSO ticket) | launcher -> gateway -> world server SessionHello/Login | OK |
 | Create character, chargen | private world `priv-<user>-<char>`; chargen sanctuary keeps the peer out of the cell | OK |
 | Resume after disconnect | resume ticket, same character, world snapshot re-sent; IP_CAP retried | FIXED 09-11 (IP_CAP was terminal RATE) |
+| Rejoin after dying and closing the tab | doc has hp 0 (death flushes); restored at 10% health on both the client and the peer's avatar, where they fell | FIXED 09-11 (was: die again on arrival, second "has fallen", respawn loop) |
 | Join a friend (party) | joinFriend -> ownerWorld (occupied) -> switch -> mayJoinWorld -> chargen gate -> guestSpawn beside owner | FIXED 09-10 |
 | Owner flips party -> private | WorldClosed, 5 s grace, guests switched home | OK |
 | Leave / kick / ban | terminal codes; SUPERSEDED for a second tab | OK |

--- a/server/src/core/combat.ts
+++ b/server/src/core/combat.ts
@@ -85,7 +85,7 @@ function parseTarget(v: LValue | undefined): CombatTarget | null {
   const cellKey = str(t.get('cellKey'), MAX_CELL_KEY);
   const rawEpoch = t.get('epoch');
   const epoch = rawEpoch === undefined ? undefined : finite(rawEpoch);
-  if (!ref || ref.kind !== 'ref' || !cellKey) return null; // actors are content refs
+  if (!ref || !cellKey) return null; // a content ref, or the net id of a runtime actor the holder named
   if (rawEpoch !== undefined && epoch === undefined) return null; // present but not a number
   return { kind: 'actor', ref, cellKey, ...(epoch !== undefined ? { epoch } : {}) };
 }

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -767,9 +767,18 @@ export function pushAvatarsToPeer(ctx: StateCtx, peer: Player): void {
 // like any client; this is the join-time snapshot that must precede the avatar acting.
 export function avatarStateBody(id: number, doc: PlayerDoc, liveBounty?: number): JsLike {
   const bounty = liveBounty ?? doc.bounty;
+  // NEVER BUILD A CORPSE. Death is a flush point, so a character who died and left has hp 0
+  // on record; an avatar built from that is dead on arrival and its first bar report kills
+  // the player who just rejoined (identity.lua restores them at a sliver for the same
+  // reason -- the two copies must agree). The death was already paid for last session.
+  let stats = doc.stats;
+  const hp = stats?.dynamic?.hp;
+  if (stats && hp && hp.c <= 0) {
+    stats = { ...stats, dynamic: { ...stats.dynamic!, hp: { c: Math.max(1, Math.floor(hp.b * 0.1)), b: hp.b } } };
+  }
   return {
     id,
-    ...(doc.stats ? { stats: doc.stats } : {}),
+    ...(stats ? { stats } : {}),
     ...(doc.spells ? { spells: doc.spells } : {}),
     ...(doc.inventory ? { inventory: doc.inventory } : {}),
     ...(doc.itemStates ? { itemStates: doc.itemStates } : {}),

--- a/server/src/core/quests.ts
+++ b/server/src/core/quests.ts
@@ -547,7 +547,9 @@ export class Quests {
     const ref = parseObjRef(body);
     const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
     const want = body.get('want');
-    if (!ref || ref.kind !== 'ref' || !cellKey || typeof want !== 'boolean') {
+    // A content ref, or the net id of a runtime actor the holder named (a script-placed
+    // quest NPC is one): the lock keys on ref.key either way.
+    if (!ref || !cellKey || typeof want !== 'boolean') {
       this.drop(player, 'DialogueLock', 'invalid shape');
       return;
     }

--- a/server/src/core/quests.ts
+++ b/server/src/core/quests.ts
@@ -414,7 +414,9 @@ export class Quests {
     const name = str(body.get('name'));
     const value = finite(body.get('value'));
     const cellKey = player.cellKey;
-    if (!ref || ref.kind !== 'ref' || !name || value === undefined || !cellKey) {
+    // A content ref, or the net id of a runtime actor the holder named (a script-placed NPC
+    // runs its own local script like any other).
+    if (!ref || !name || value === undefined || !cellKey) {
       this.drop(player, 'MemberVarUpdate', 'invalid shape or no cell');
       return;
     }

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -479,12 +479,15 @@ export class WorldState {
       holder.peer.sendEvent('ActorAI', { ...objRefToJs(f.ref), cellKey, epoch: 0, follow: f.follow, ...(f.escort ? { escort: f.escort } : {}) });
     }
   }
+  // The four non-holder claims below accept a content ref OR the net id of a runtime actor
+  // the holder named: a quest NPC placed by a script is a net actor, and it can be talked
+  // to, recruited, taunted and sent walking like any other.
   private followClaim(player: Player, body: LTable): void {
     const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
     const ref = parseObjRef(body);
     const rawFollow = body.get('follow');
     const follow = rawFollow === undefined ? undefined : finite(rawFollow);
-    if (!cellKey || !ref || ref.kind !== 'ref' || (rawFollow !== undefined && follow !== player.id)) {
+    if (!cellKey || !ref || (rawFollow !== undefined && follow !== player.id)) {
       this.invalid(player, 'ActorAI');
       return;
     }
@@ -551,7 +554,7 @@ export class WorldState {
         const t = body.get('travel');
         const tt = t instanceof Map ? t as LTable : undefined;
         const x = tt ? finite(tt.get('x')) : undefined, y = tt ? finite(tt.get('y')) : undefined, z = tt ? finite(tt.get('z')) : undefined;
-        if (!cellKey || !ref || ref.kind !== 'ref' || x === undefined || y === undefined || z === undefined
+        if (!cellKey || !ref || x === undefined || y === undefined || z === undefined
           || Math.abs(x) > MAX_ABS_COORD || Math.abs(y) > MAX_ABS_COORD || Math.abs(z) > MAX_ABS_COORD) {
           this.invalid(player, name);
           return;
@@ -571,7 +574,7 @@ export class WorldState {
         const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
         const ref = parseObjRef(body);
         const combat = finite(body.get('combat'));
-        if (!cellKey || !ref || ref.kind !== 'ref' || combat !== player.id) { this.invalid(player, name); return; }
+        if (!cellKey || !ref || combat !== player.id) { this.invalid(player, name); return; }
         if (player.system || this.dialogueHolder?.(ref.key) !== player.id || !cellsVisible(player.cellKey, cellKey)) {
           log('warn', 'actor.dropped', { from: player.name, name, cellKey, why: 'combat claim without the conversation' });
           return;
@@ -591,7 +594,7 @@ export class WorldState {
       const cellKey = str(body.get('cellKey'), MAX_CELL_KEY);
       const ref = parseObjRef(body);
       const disposition = finite(body.get('disposition'));
-      if (!cellKey || !ref || ref.kind !== 'ref' || disposition === undefined || disposition < 0 || disposition > 100) {
+      if (!cellKey || !ref || disposition === undefined || disposition < 0 || disposition > 100) {
         this.invalid(player, name);
         return;
       }

--- a/server/test/avatarstate.test.ts
+++ b/server/test/avatarstate.test.ts
@@ -154,3 +154,17 @@ test('a guard reaching an avatar on the peer reaches the owner as PlayerArrest; 
   assert.equal(a.inbox.events.filter((e) => e.name === 'PlayerCrime').length, 0,
     'a client made another player wanted');
 });
+
+// NEVER BUILD A CORPSE. A character who died and closed the tab has hp 0 on record (death is
+// a flush point). The avatar the peer builds for their rejoin must not be dead on arrival, or
+// its first bar report kills the player who just came back.
+test("a character who left dead is handed to the peer with a sliver of health, not a corpse", async (t) => {
+  const { server, a } = await bootWithCharacter(t);
+  a.sendEvent('PlayerStatsDynamic', { hp: { c: 0, b: 80 }, mp: { c: 10, b: 50 }, ft: { c: 5, b: 100 } });
+  await new Promise((r) => setTimeout(r, 300));
+  const peer = await TestClient.simPeer(server.port, PEER_PASS);
+  t.after(() => peer.close());
+  const got = await peer.waitEvent('AvatarState', (v) => (v as { id?: number }).id === a.playerId, 8000);
+  const hp = (got.value as { stats?: { dynamic?: { hp?: { c: number; b: number } } } }).stats?.dynamic?.hp;
+  assert.ok(hp && hp.c > 0 && hp.c <= 8 && hp.b === 80, `avatar seeded with hp ${JSON.stringify(hp)}: a corpse, or a full heal`);
+});

--- a/server/test/quests.test.ts
+++ b/server/test/quests.test.ts
@@ -303,9 +303,13 @@ test('dialogue lock', async (t) => {
   await t.test('malformed lock requests are dropped', async () => {
     b.sendEvent('DialogueLock', { ref: NPC_REF, cellKey: '5,5' }); // no want
     b.sendEvent('DialogueLock', { cellKey: '5,5', want: true }); // no ref
-    b.sendEvent('DialogueLock', { net: 5, cellKey: '5,5', want: true }); // actors are content refs
+    b.sendEvent('DialogueLock', { net: 'x', cellKey: '5,5', want: true }); // net must be an id
     await fence(b, b);
     assert.equal(b.inbox.events.filter((e) => e.name === 'DialogueLockResult').length, 0);
+    // A runtime actor the holder named (a script-placed quest NPC) is addressed by net id
+    // and can be locked like any other.
+    b.sendEvent('DialogueLock', { net: 5, cellKey: '5,5', want: true });
+    assert.deepEqual((await b.waitEvent('DialogueLockResult')).value, { ref: 5, granted: true });
   });
 });
 

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -510,5 +510,40 @@ for _, path in ipairs(mpFiles) do
   check(path:match('([^/]+)$') .. ' assigns into no table before declaring it', #bad == 0, table.concat(bad, '; '))
 end
 
+-- A `local function f` is nil above its own line: a call to it from an earlier function is a
+-- runtime "attempt to call a nil value" the stubs only reach if that path executes. Caught
+-- 2026-09-11 in quests.lua (npcAddr used by the member-var poller, declared 20 lines lower).
+-- Static, so it needs no path to execute: every `local function NAME` in a file, and every
+-- bare `NAME(` above that line that is not itself a declaration or a field access.
+local function calledBeforeDeclared(src)
+  local decl, bad, n = {}, {}, 0
+  for line in (src .. '\n'):gmatch('(.-)\n') do
+    n = n + 1
+    local name = line:match('^local%s+function%s+([%a_][%w_]*)%s*%(')
+    if name and not decl[name] then decl[name] = n end
+  end
+  n = 0
+  for line in (src .. '\n'):gmatch('(.-)\n') do
+    n = n + 1
+    local code = line:gsub('%-%-.*$', '')
+    for pre, name in code:gmatch('([^%w_%.:]?)([%a_][%w_]*)%s*%(') do
+      if decl[name] and n < decl[name] and pre ~= '.' and pre ~= ':'
+        and not code:match('^%s*local%s+function%s+' .. name .. '%s*%(')
+        and not code:match('function%s+' .. name .. '%s*%(') then
+        bad[#bad + 1] = name .. ' at line ' .. n .. ' (declared at ' .. decl[name] .. ')'
+      end
+    end
+  end
+  return bad
+end
+local negCall = calledBeforeDeclared('local function a()\n  return b()\nend\nlocal function b() return 1 end\n')
+check('the scan catches a call above the local function declaration', #negCall == 1 and negCall[1]:find('^b at line 2') ~= nil,
+  table.concat(negCall, '; '))
+for _, path in ipairs(mpFiles) do
+  local f = io.open(path); local src = f:read('*a'); f:close()
+  local bad = calledBeforeDeclared(src)
+  check(path:match('([^/]+)$') .. ' calls no local function above its declaration', #bad == 0, table.concat(bad, '; '))
+end
+
 print(string.format('\n%d passed, %d failed', pass, fail))
 os.exit(fail == 0 and 0 or 1)


### PR DESCRIPTION
The dialogue lock and the non-holder claims required a content ref; a runtime-named quest NPC has only a net id, so its dialogue never opened and nothing said in it could reach the holder. Both sides now address such an NPC by net id. tsc clean; quests/actor suites green; Lua runner 90/90. Native-peer harness: s51 PASS on today's code (s40/s42 self-skipped on host load, as documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)