### PR TITLE
With PvP off, another player's scamp could bite you

### DIFF
--- a/openmw/apps/openmw/mwmechanics/summoning.cpp
+++ b/openmw/apps/openmw/mwmechanics/summoning.cpp
@@ -1,3 +1,4 @@
+#include "../mwmp/puppets.hpp"
 #include "summoning.hpp"
 
 #include <components/debug/debuglog.hpp>
@@ -118,6 +119,7 @@ namespace MWMechanics
                 MWWorld::Ptr placed = world->safePlaceObject(ref.getPtr(), summoner, summoner.getCell(), 0, 120.f);
                 MWBase::Environment::get().getWorldModel()->registerPtr(placed);
                 creature = placed.getCellRef().getRefNum();
+                MWMP::noteSummon(creature, summoner.getCellRef().getRefNum());
 
                 // Make the summoned creature follow its master and help in fights
                 AiFollow package(summoner);

--- a/openmw/apps/openmw/mwmp/luabindings.cpp
+++ b/openmw/apps/openmw/mwmp/luabindings.cpp
@@ -274,6 +274,15 @@ namespace MWMP
             return out;
         };
         // Client: whether the player's own Summon effects spawn a creature HERE (see puppets.hpp).
+        // The actor that summoned this creature, or nil (mwmp/puppets.hpp noteSummon).
+        api["summonerOf"] = [](sol::this_state state, const sol::object& obj) -> sol::object {
+            if (!obj.is<MWLua::Object>())
+                return sol::nil;
+            const ESM::RefNum master = summonerOf(obj.as<MWLua::Object>().id());
+            if (!master.isSet())
+                return sol::nil;
+            return sol::make_object(state, MWLua::GObject(master));
+        };
         api["setLocalSummons"] = [](bool enabled) { setLocalSummons(enabled); };
         api["setLocalSpawns"] = [](bool enabled) { setLocalSpawns(enabled); };
         api["isEnabled"] = []() { return std::getenv("OPENMW_MP_URL") != nullptr; };

--- a/openmw/apps/openmw/mwmp/puppets.cpp
+++ b/openmw/apps/openmw/mwmp/puppets.cpp
@@ -180,6 +180,29 @@ namespace MWMP
         }
     }
 
+    namespace
+    {
+        std::unordered_map<ESM::RefNum, ESM::RefNum, RefNumHash, RefNumEq>& summoners()
+        {
+            static std::unordered_map<ESM::RefNum, ESM::RefNum, RefNumHash, RefNumEq> m;
+            return m;
+        }
+    }
+
+    void noteSummon(ESM::RefNum creature, ESM::RefNum summoner)
+    {
+        auto& m = summoners();
+        if (m.size() > 4096)
+            m.clear(); // a session's worth of summons; never a leak
+        m[creature] = summoner;
+    }
+
+    ESM::RefNum summonerOf(ESM::RefNum creature)
+    {
+        const auto it = summoners().find(creature);
+        return it == summoners().end() ? ESM::RefNum{} : it->second;
+    }
+
     void recordCrime(ESM::RefNum avatar, int bounty, std::string kind)
     {
         auto& av = avatars();

--- a/openmw/apps/openmw/mwmp/puppets.hpp
+++ b/openmw/apps/openmw/mwmp/puppets.hpp
@@ -96,6 +96,11 @@ namespace MWMP
     /** Drain the guards that reached ONE avatar since the last call. */
     std::vector<ESM::RefNum> takeArrestsFor(ESM::RefNum avatar);
 
+    /** Which actor summoned a creature (summoning.cpp). A summon is its master's hand: with
+     *  pvp off, another player's scamp must not bite an avatar its master could not. */
+    void noteSummon(ESM::RefNum creature, ESM::RefNum summoner);
+    ESM::RefNum summonerOf(ESM::RefNum creature); // empty RefNum when unknown
+
     /** A crime an avatar committed HERE and somebody reported (reportCrime). The bounty is the
      *  owner's, on their client; the peer cannot write it, so the increment is recorded for
      *  the scripts to forward. The registry bounty is bumped at once so the pursuit that

--- a/openmw/files/data/scripts/mp/avatar.lua
+++ b/openmw/files/data/scripts/mp/avatar.lua
@@ -46,7 +46,16 @@ local function registerHitVeto()
         if pvpEnabled then return end
         local a = attack.attacker
         local ok, aid = pcall(function() return a and a.id end)
-        if ok and aid and avatarObjIds[aid] then return false end
+        if not (ok and aid) then return end
+        if avatarObjIds[aid] then return false end
+        -- A SUMMON IS ITS SUMMONER'S HAND. The peer summons for every player now, and a
+        -- summon attacks what its master engages: with pvp off another player's scamp could
+        -- bite this avatar when the player could not. The engine records who summoned what.
+        if mp.summonerOf then
+            local okm, master = pcall(mp.summonerOf, a)
+            local okid, mid = pcall(function() return master and master.id end)
+            if okm and okid and mid and avatarObjIds[mid] then return false end
+        end
     end)
 end
 

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -89,7 +89,7 @@ known and recorded; N/A = does not exist in single player either.
 | Scripted enable/disable of refs | ObjectEnabled persisted | OK |
 | Locks, lockpicking, script Lock/Unlock | lockWatch relay, persisted | OK |
 | Trap disarm state | not in the cell doc | GAP (harmless while trap damage is discarded) |
-| Cell resets | server sweep; clients handed restored truth | OK |
+| Cell resets | server sweep; clients handed restored truth; named runtime actors are dropped with the doc and removed on every engine (the peer re-rolls and re-names) | OK |
 | Dynamic records (alchemy, enchant, spellmaking) | RecordsSync chunked; toNet/toLocal at every seam | OK |
 
 ## 6. NPC behaviour (the peer as holder)

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -54,7 +54,7 @@ known and recorded; N/A = does not exist in single player either.
 | NPC/creature aggression at players | engageCombat treats avatars as players | FIXED 09-11 |
 | NPC retaliation when hit | actorAttacked treats avatar attacker as player | FIXED 09-11 |
 | Being hit: damage, disease, paralysis | peer bars -> SelfStats; AvatarEffectsBatch -> SelfSpells/SelfActiveSpells | FIXED 09-11 |
-| PvP | server veto (pvp rules) + avatar hit veto on the peer | OK |
+| PvP | server veto (pvp rules) + avatar hit veto on the peer; a summon's blow is vetoed when its master is another player's avatar | FIXED 09-11 (summons bypassed pvp-off) |
 | Death | death edge flushed; respawn plugin; avatar rebuilt; puppet rebuilt on other screens | FIXED 09-10 |
 | Kill credit / GetDeadCount | ActorDeath tally shared | OK (attribution logs only) |
 | Companions fight beside you | siding-with on the peer | OK |


### PR DESCRIPTION
Summons now come from the peer for every player, and the avatar hit veto covered avatar-vs-avatar blows only. The engine records summoner→creature (`noteSummon`), exposes `mp.summonerOf`, and the veto refuses a summon's blow when its master is another player's avatar. NPC summons untouched. Lua runner 110/110; native peer compile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)