### PR TITLE
What you gave your companion existed on your screen only

### DIFF
--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -85,6 +85,10 @@ local lastPoseMirror = 0
 local GOLD_SERVICE_MODES = {
     Barter = true, Training = true, Travel = true, SpellBuying = true,
     SpellCreation = true, Enchanting = true, MerchantRepair = true,
+    -- COMPANION SHARE is the same shape: a live actor's inventory, open in a window, moved
+    -- both ways, reconciled once on close. Without it what you handed your follower existed
+    -- on your screen only; the peer's copy -- the one that fights -- carried none of it.
+    Companion = true,
 }
 
 local barterTarget = nil -- harness 'barter:open': the NPC whose purse is mirrored

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -127,7 +127,7 @@ known and recorded; N/A = does not exist in single player either.
 | Scripted Disable/SetDelete of a named runtime actor | holder sees it gone -> ObjectDelete by net id; holder loss purges the cell's named actors | FIXED 09-11 |
 | Scripted PositionCell/SetPos of an NPC | runs on every engine; holder's poses/ActorCellChange win | OK |
 | ForceGreeting | client-side dialogue, no lock taken | OK (two players may both be forced; harmless) |
-| Companion share (follower inventory) | actor inventory as a container: ContainerOp canonical, relayed to the holder | OK |
+| Companion share (follower inventory) | the Companion window is watched like Barter: canonical on open, one diff on close, applied into the live actor's inventory on every engine (the peer's copy fights with it) | FIXED 09-11 (was: local to the giver's screen) |
 | StartScript/StopScript | runs per engine; globals reconcile | OK |
 
 ## 8. World


### PR DESCRIPTION
The companion-share window was unwatched; the Companion UI mode now rides the same live-container path as Barter (canonical on open, one diff on close, applied into the live actor's inventory on every engine). Lua runner 110/110; no server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)