### PR TITLE
An NPC's Dispel stripped your Levitate from the avatar and left you flying

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -744,6 +744,7 @@ local avatarEffectsAt = 0
 local AVATAR_EFFECTS_EVERY = 1.0
 local avatarSpellsReported = {} -- id -> { localSpellId -> true }
 local avatarEffectsReported = {} -- id -> { activeSpellId -> localRecordId }
+local avatarOwnerEffectsSeen = {} -- id -> { activeSpellId -> localRecordId } owner records seen on the avatar
 
 local function avatarEffectsTick(now)
     if not (mp.isSystem and mp.isSystem()) then return end
@@ -774,8 +775,17 @@ local function avatarEffectsTick(now)
             local known = ownerActive[id] or {}
             local seen = {}
             local reported = avatarEffectsReported[id] or {}
+            -- Owner-applied records are tracked too, by instance, so a Dispel that strips
+            -- the owner's Levitate from the avatar reaches the owner as a removal (else they
+            -- keep flying while their body falls). They are never reported as ADDS: the
+            -- owner put them there.
+            local ownerSeen = {}
+            local ownerReported = avatarOwnerEffectsSeen[id] or {}
             local okE = pcall(function()
                 for _, sp in pairs(types.Actor.activeSpells(p.obj)) do
+                    if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil and known[sp.id] then
+                        ownerSeen[sp.activeSpellId] = sp.id
+                    end
                     if sp.temporary and not sp.fromEquipment and sp.activeSpellId ~= nil
                         and not known[sp.id] then
                         seen[sp.activeSpellId] = sp.id
@@ -802,6 +812,17 @@ local function avatarEffectsTick(now)
                     end
                 end
                 avatarEffectsReported[id] = seen
+                -- An owner record that was on the avatar and is gone before the owner said
+                -- so: dispelled (or absorbed) here. The owner's own expiry also lands here a
+                -- tick before its removal arrives; the client-side remove is idempotent.
+                for aid, rid in pairs(ownerReported) do
+                    if not ownerSeen[aid] and known[rid] then
+                        entry.effectsRemove = entry.effectsRemove or {}
+                        entry.effectsRemove[#entry.effectsRemove + 1] = { id = worldmp.toNet(rid) }
+                        any = true
+                    end
+                end
+                avatarOwnerEffectsSeen[id] = ownerSeen
             end
             if (okS or okE) and any then entries[#entries + 1] = entry end
         end
@@ -963,6 +984,7 @@ local function despawnPuppet(id)
     ownerActive[id] = nil
     avatarSpellsReported[id] = nil
     avatarEffectsReported[id] = nil
+    avatarOwnerEffectsSeen[id] = nil
     -- Guarded, and deliberately AFTER the bookkeeping above: remove() throws when the
     -- object is already gone or otherwise not removable ("Can't remove 0 of 0 items"), and
     -- an engine handler that throws ABORTS — which took the rest of MP_PlayerLeaveWorld

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -54,7 +54,7 @@ known and recorded; N/A = does not exist in single player either.
 | NPC/creature aggression at players | engageCombat treats avatars as players | FIXED 09-11 |
 | NPC retaliation when hit | actorAttacked treats avatar attacker as player | FIXED 09-11 |
 | Being hit: damage, disease, paralysis | peer bars -> SelfStats; AvatarEffectsBatch -> SelfSpells/SelfActiveSpells | FIXED 09-11 |
-| Being dispelled by an NPC | a Dispel that strips an OWNER-applied effect (Levitate) from the avatar is not reported back (the peer diff skips owner records); the owner keeps flying until the effect's own timer | GAP (narrow; Dispel-casting NPCs are rare) |
+| Being dispelled by an NPC | owner-applied records are tracked by instance on the avatar; one that vanishes before the owner removed it (Dispel, absorb) is reported back as a removal and the owner's engine drops it | FIXED 09-11 |
 | PvP | server veto (pvp rules) + avatar hit veto on the peer; a summon's blow is vetoed when its master is another player's avatar | FIXED 09-11 (summons bypassed pvp-off) |
 | Death | death edge flushed; respawn plugin; avatar rebuilt; puppet rebuilt on other screens | FIXED 09-10 |
 | Kill credit / GetDeadCount | ActorDeath tally shared | OK (attribution logs only) |

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -54,6 +54,7 @@ known and recorded; N/A = does not exist in single player either.
 | NPC/creature aggression at players | engageCombat treats avatars as players | FIXED 09-11 |
 | NPC retaliation when hit | actorAttacked treats avatar attacker as player | FIXED 09-11 |
 | Being hit: damage, disease, paralysis | peer bars -> SelfStats; AvatarEffectsBatch -> SelfSpells/SelfActiveSpells | FIXED 09-11 |
+| Being dispelled by an NPC | a Dispel that strips an OWNER-applied effect (Levitate) from the avatar is not reported back (the peer diff skips owner records); the owner keeps flying until the effect's own timer | GAP (narrow; Dispel-casting NPCs are rare) |
 | PvP | server veto (pvp rules) + avatar hit veto on the peer; a summon's blow is vetoed when its master is another player's avatar | FIXED 09-11 (summons bypassed pvp-off) |
 | Death | death edge flushed; respawn plugin; avatar rebuilt; puppet rebuilt on other screens | FIXED 09-10 |
 | Kill credit / GetDeadCount | ActorDeath tally shared | OK (attribution logs only) |


### PR DESCRIPTION
The peer's effect diff skipped owner-applied records, so a Dispel/absorb on the avatar reached nobody and the owner kept flying into the ground. Owner records are now tracked by instance and a vanished one is reported back as a removal. Lua runner 110/110; no server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)