### PR TITLE
You could not pick your arrows back up: the world's runtime items stayed on the peer

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1283,6 +1283,13 @@ local function start()
     -- M3 world-object hub wiring (see scripts/mp/objects.lua).
     objects.init({
         playerFn = playerScript,
+        allAvatarsFn = function()
+            local out = {}
+            for _, p in pairs(puppets) do
+                if p.obj and p.obj:isValid() then out[#out + 1] = p.obj end
+            end
+            return out
+        end,
         ownCellKeyFn = function() return ownCellKeyCache end,
         ownIdFn = function() return net.state == 'Joined' and net.playerId or nil end,
         placeholderItemFn = placeholderItemId,

--- a/openmw/files/data/scripts/mp/objects.lua
+++ b/openmw/files/data/scripts/mp/objects.lua
@@ -536,6 +536,22 @@ function objects.onItemActive(item)
     for _, obj in pairs(pendingSpawns) do
         if obj.id == item.id then return end
     end
+    -- ON THE PEER a runtime item is the WORLD's: an arrow the avatar shot and missed, ammo
+    -- a creature dropped when it died, an item a script placed. Its own player is a dummy
+    -- parked far from everyone, so the range test below never passed and every such item
+    -- stayed on the peer's engine alone -- you could not pick your arrows back up. Named as
+    -- a placement (no owner, no conservation debit) when it appears near any avatar.
+    if mp.isSystem and mp.isSystem() then
+        if not (deps.allAvatarsFn and item.cell) then return end
+        for _, av in ipairs(deps.allAvatarsFn()) do
+            local okd, d = pcall(function() return (item.position - av.position):length() end)
+            if okd and d <= DROP_DETECT_RANGE then
+                objects.requestSpawn(item, nil, nil, false)
+                return
+            end
+        end
+        return
+    end
     local player = deps.playerFn()
     if not player then return end
     local ok, dist = pcall(function() return (item.position - player.position):length() end)

--- a/openmw/files/data/scripts/mp/quests.lua
+++ b/openmw/files/data/scripts/mp/quests.lua
@@ -481,7 +481,11 @@ end
 function quests.onNpcActivate(obj, actor)
     local player = playerObj()
     if not player or not actor or actor.id ~= player.id then return end
-    if deps.isMpPuppetFn and deps.isMpPuppetFn(obj) then return end -- remote players aren't NPCs to lock
+    -- A REMOTE PLAYER'S BODY IS NOT AN NPC. Letting the engine's own activation through opened
+    -- a dialogue window on a friend (blank: the puppet record has no dialogue) and, on a
+    -- fallen friend, the LOOT window on their puppet -- a per-screen copy of their inventory
+    -- that nothing on the wire backs. Player-to-player exchange is a drop and a pickup.
+    if deps.isMpPuppetFn and deps.isMpPuppetFn(obj) then return false end
     if not npcAddr(obj) then return end -- no portable ref: cannot be arbitrated
     if lockAllowOnce == obj.id then
         lockAllowOnce = nil

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -45,7 +45,7 @@ known and recorded; N/A = does not exist in single player either.
 | Action | MP path | Status |
 |---|---|---|
 | Melee vs NPC | client swing cancelled; avatar swings on peer (stance, use bit) | FIXED 09-10 |
-| Ranged | avatar fires; ammo reconciled via inventory | OK |
+| Ranged | avatar fires; ammo reconciled via inventory; a missed arrow (and any runtime item the world creates near an avatar: death drops, scripted items) is named by the peer as a world placement, so it can be picked up on every screen | FIXED 09-11 (was: peer-local, arrows unrecoverable) |
 | Blocking, armor, difficulty | peer engine, avatar treated as player for scaling | OK |
 | Spell at NPC (touch/target) | client casts; hit on puppet recorded -> CombatSpellHit -> holder applies record | OK |
 | Self-cast / potion / scroll | PlayerActiveSpells -> avatar (spell stance = Nothing on avatar) | FIXED 09-11 |

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -57,6 +57,7 @@ known and recorded; N/A = does not exist in single player either.
 | Being dispelled by an NPC | owner-applied records are tracked by instance on the avatar; one that vanishes before the owner removed it (Dispel, absorb) is reported back as a removal and the owner's engine drops it | FIXED 09-11 |
 | PvP | server veto (pvp rules) + avatar hit veto on the peer; a summon's blow is vetoed when its master is another player's avatar | FIXED 09-11 (summons bypassed pvp-off) |
 | Death | death edge flushed; respawn plugin; avatar rebuilt; puppet rebuilt on other screens | FIXED 09-10 |
+| Activating another player's body (alive or dead) | refused: no blank dialogue on a friend, no loot window on a fallen one (that copy is per-screen and unbacked); player-to-player exchange is drop + pickup | FIXED 09-11 |
 | Kill credit / GetDeadCount | ActorDeath tally shared | OK (attribution logs only) |
 | Companions fight beside you | siding-with on the peer | OK |
 | Resting refused mid-fight | holder relays combat state; puppet carries Combat package | FIXED 09-11 |

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -768,7 +768,9 @@ export class WorldState {
     // so the Lua suite discovers these reasons and holds the client to wording each of them.
     const reply = (ok: boolean, reason: string) =>
       player.peer.sendEvent('ObjectSpawnRefused', { tempId, ok, reason });
-    const held = actor ? undefined : this.heldCount?.(player, recordId);
+    // The world peer owns nothing and drops nothing: what it places is the world's (a missed
+    // arrow, a creature's death drop, a scripted item, a named runtime actor). Never judged.
+    const held = actor || player.system === true ? undefined : this.heldCount?.(player, recordId);
     if (held !== undefined && held < count) {
       metrics.unownedDrops.inc();
       this.moderationNote?.(player.accountKey, 'unowned_drop');


### PR DESCRIPTION
The peer never named items the world created near an avatar (missed arrows, death drops, scripted items) because its own player is a far-away dummy. It now names them as ownerless placements, and the server exempts the world peer from the ownership ledger. Lua runner 110/110; tsc clean; objects/actor suites green; full suite before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)