### PR TITLE
No friend could join anyone: the directory's idea of a world's mode was fixed at process start

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -1869,6 +1869,9 @@ local eventHandlers = {
     -- ACTION, so the redial happens here; the hub is told first so it can show a failure.
     MP_JoinFriend = function(data)
         toPlayer('MP_JoinFriend', data)
+        -- The server's exact answer, for the scenarios: a refusal in place looks like nothing
+        -- happened from the host's screen, and the reason is the whole diagnosis.
+        pcall(function() mp.set('joinFriendResult', json.encode({ ok = data and data.ok, error = data and data.error, worldId = data and data.worldId })) end)
         if not data or data.ok ~= true then return end
         local url = worldUrlOf(data)
         if not url then return end
@@ -2439,6 +2442,7 @@ local eventHandlers = {
         }
         local op = tostring(data.op or '')
         if not OPS[op] then return end
+        if op == 'JoinFriend' then print('[mp] JoinFriend sent for ' .. tostring(data.acct)) end
         mp.sendEvent(op, {
             name = data.name, acct = data.acct, mode = data.mode, id = data.id,
             target = data.target, kind = data.kind, payload = data.payload,

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -450,7 +450,10 @@ local function dispatch(cmd)
 
         -- Cross-world join a friend.
         local jfAcct = cmd:match('^joinfriend:(.+)$')
-        if jfAcct then core.sendGlobalEvent('mpSocial', { op = 'JoinFriend', acct = jfAcct }) end
+        if jfAcct then
+            print('[mp] joinfriend command for ' .. jfAcct)
+            core.sendGlobalEvent('mpSocial', { op = 'JoinFriend', acct = jfAcct })
+        end
         -- Owner in-place Solo<->Party flip of their own world.
         local wmMode = cmd:match('^worldmode:(%a+)$')
         if wmMode then core.sendGlobalEvent('mpSocial', { op = 'SetWorldMode', mode = wmMode }) end

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -30,7 +30,7 @@ s40/s42 (host-load guard). Anything below marked OK without a scenario is a code
 | Create character, chargen | private world `priv-<user>-<char>`; chargen sanctuary keeps the peer out of the cell | OK |
 | Resume after disconnect | resume ticket, same character, world snapshot re-sent; IP_CAP retried | FIXED 09-11 (IP_CAP was terminal RATE) |
 | Rejoin after dying and closing the tab | doc has hp 0 (death flushes); restored at 10% health on both the client and the peer's avatar, where they fell | FIXED 09-11 (was: die again on arrival, second "has fallen", respawn loop) |
-| Join a friend (party) | joinFriend -> ownerWorld (occupied) -> switch -> mayJoinWorld -> chargen gate -> guestSpawn beside owner | FIXED 09-10 |
+| Join a friend (party) | joinFriend -> ownerWorld (occupied, LIVE mode from the world's /status) -> switch -> mayJoinWorld -> chargen gate -> guestSpawn beside owner | FIXED 09-11 (the 09-10 pre-switch mode check read a mode fixed at process start, so every join was refused as not_open; caught live by s95) |
 | Owner flips party -> private | WorldClosed, 5 s grace, guests switched home | OK |
 | Leave / kick / ban | terminal codes; SUPERSEDED for a second tab | OK |
 | Save / Load / quicksave | refused at StateManager while Joined; menu items hidden | OK |

--- a/server/src/core/social.ts
+++ b/server/src/core/social.ts
@@ -791,7 +791,12 @@ export class Social {
   // Friendship is required both ways — you cannot chase a stranger across worlds.
   async joinFriend(player: Player, targetAcct: AccountKey): Promise<void> {
     const me = player.accountKey;
-    const fail = (detail: string): void => player.peer.sendEvent('JoinFriend', { ok: false, error: detail });
+    const fail = (detail: string): void => {
+      // Logged: a refusal here is invisible from every other screen (the guest stays put), and
+      // the reason is the whole diagnosis when "join my friend" does nothing.
+      log('info', 'social.join_refused', { player: player.name, target: targetAcct, why: detail });
+      player.peer.sendEvent('JoinFriend', { ok: false, error: detail });
+    };
     if (targetAcct === '' || targetAcct === me) return fail('self');
     if (!this.d.store.areFriends(me, targetAcct)) return fail('not_friends');
     if (this.d.store.blockedEitherWay(me, targetAcct)) return fail('blocked');

--- a/server/src/core/worldbrowser.ts
+++ b/server/src/core/worldbrowser.ts
@@ -103,6 +103,22 @@ export class WorldBrowser {
     return mine.find((w) => w.playerCount > 0) ?? mine[0];
   }
 
+  // Tell the directory this world's mode changed, now, so a friend's join reads the truth
+  // before the next poll. Best effort: the poll still observes it within its interval.
+  async reportMode(worldId: string, ownerAccount: string, mode: 'private' | 'party'): Promise<void> {
+    if (!this.enabled) return;
+    const token = this.deps.serverToken ?? '';
+    if (!token) return;
+    const r = await this.call(`/worlds/${encodeURIComponent(worldId)}`, {
+      method: 'PATCH',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ mode, account: ownerAccount }),
+    });
+    if (!r || (typeof r === 'object' && '__httpError' in r)) {
+      log('warn', 'worldbrowser.mode_report_failed', { worldId, mode, status: (r as { __httpError?: number } | null)?.__httpError ?? 'unreachable' });
+    }
+  }
+
   async create(player: Player, id: string, mode: string): Promise<{ world?: WorldEntry; error?: string }> {
     if (!this.enabled) return { error: 'no_gateway' };
     if (mode !== 'private' && mode !== 'party') return { error: 'bad_mode' };

--- a/server/src/gateway/directory.ts
+++ b/server/src/gateway/directory.ts
@@ -283,6 +283,27 @@ export async function startDirectory(deps: DirectoryDeps): Promise<RunningDirect
       return;
     }
 
+    // A world process reporting its owner's Solo<->Party flip (server.ts setWorldMode).
+    // Trusted-server credential only -- a player cannot open somebody else's world from
+    // outside -- and the account named must be that world's owner.
+    if (req.method === 'PATCH' && path.startsWith('/worlds/')) {
+      const id = decodeURIComponent(path.slice('/worlds/'.length));
+      let body = '';
+      req.on('data', (c) => { body += c; if (body.length > 1024) req.destroy(); });
+      req.on('end', () => {
+        if (!deps.isTrustedServer?.(req.headers.authorization ?? '')) { json(res, 401, { error: 'server credential required' }); return; }
+        let parsed: { mode?: unknown; account?: unknown } = {};
+        try { parsed = JSON.parse(body || '{}'); } catch { json(res, 400, { error: 'bad json' }); return; }
+        if (parsed.mode !== 'private' && parsed.mode !== 'party') { json(res, 400, { error: 'mode must be private or party' }); return; }
+        const w = deps.worlds.get(id);
+        if (!w) { json(res, 404, { error: 'no such world' }); return; }
+        if (w.ownerAccount !== undefined && parsed.account !== w.ownerAccount) { json(res, 403, { error: 'not the owner' }); return; }
+        deps.worlds.setMode(id, parsed.mode);
+        json(res, 200, { id, mode: parsed.mode });
+      });
+      return;
+    }
+
     if (req.method === 'POST' && path === '/harness/session' && deps.mintHarnessSession) {
       let body = '';
       req.on('data', (c) => { body += c; if (body.length > 4096) req.destroy(); });

--- a/server/src/gateway/worlds.ts
+++ b/server/src/gateway/worlds.ts
@@ -136,7 +136,7 @@ export interface WorldDeps {
   // peerCount is OPTIONAL here and required on World.lastStatus: a world from an older build --
   // or a test fake that predates peers being per-cell -- simply does not report it, and poll()
   // normalises the absence to 1 rather than making every caller restate the default.
-  fetchStatus?: (port: number) => Promise<{ playerCount: number; connectedCount: number; peerCount?: number; maxPlayers: number; name: string; players?: WorldPlayer[] } | null>;
+  fetchStatus?: (port: number) => Promise<{ playerCount: number; connectedCount: number; peerCount?: number; maxPlayers: number; name: string; players?: WorldPlayer[]; mode?: WorldMode } | null>;
   now?: () => number;
 }
 
@@ -432,6 +432,13 @@ export class WorldSupervisor {
     await Promise.all([...this.worlds.values()].map(async (w) => {
       const st = await fetchStatus(w.port);
       if (st) {
+        // THE WORLD'S MODE IS THE WORLD'S TO SAY. It was fixed here at process start
+        // (OMW_WORLD_MODE), so an owner's flip to Party never reached the directory: the
+        // friend-join check read the stale 'private' and refused every friend as not_open.
+        if (st.mode && st.mode !== w.mode) {
+          log('info', 'world.mode_observed', { id: w.id, from: w.mode, to: st.mode });
+          w.mode = st.mode;
+        }
         // Normalised HERE so the rest of the supervisor reads a definite number. Absent means a
         // world that predates the field, which runs at least the one peer worldCostMb already
         // includes -- reading it as 0 would price such a world as free to the memory governor.
@@ -649,11 +656,11 @@ function delay(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function defaultFetchStatus(port: number): Promise<{ playerCount: number; connectedCount: number; peerCount: number; maxPlayers: number; name: string; players: WorldPlayer[] } | null> {
+async function defaultFetchStatus(port: number): Promise<{ playerCount: number; connectedCount: number; peerCount: number; maxPlayers: number; name: string; players: WorldPlayer[]; mode?: WorldMode } | null> {
   try {
     const r = await fetch(`http://127.0.0.1:${port}/status`, { signal: AbortSignal.timeout(2000) });
     if (!r.ok) return null;
-    const j = await r.json() as { playerCount?: number; connectedCount?: number; peerCount?: number; maxPlayers?: number; name?: string; players?: unknown };
+    const j = await r.json() as { playerCount?: number; connectedCount?: number; peerCount?: number; maxPlayers?: number; name?: string; players?: unknown; mode?: unknown };
     // The roster, kept this time. Shape-checked row by row: a game from an older build sends
     // no list at all, and a row missing a name is not a player.
     const players: WorldPlayer[] = Array.isArray(j.players)
@@ -679,6 +686,7 @@ async function defaultFetchStatus(port: number): Promise<{ playerCount: number; 
       peerCount: typeof j.peerCount === 'number' ? j.peerCount : 1,
       maxPlayers: typeof j.maxPlayers === 'number' ? j.maxPlayers : 0,
       name: typeof j.name === 'string' ? j.name : `world:${port}`,
+      ...(j.mode === 'party' || j.mode === 'private' ? { mode: j.mode } : {}),
     };
   } catch {
     return null; // not up yet, or wedged — either way it is not joinable

--- a/server/src/gateway/worlds.ts
+++ b/server/src/gateway/worlds.ts
@@ -260,6 +260,19 @@ export class WorldSupervisor {
     return this.list().find((w) => w.id === id);
   }
 
+  // THE WORLD TELLS US, THE MOMENT IT HAPPENS. The poll also observes a flip, but five
+  // seconds later -- and a friend who clicks "join" the instant their host says "I'm open"
+  // was refused as not_open inside that window, which is the normal human timing.
+  setMode(id: string, mode: WorldMode): boolean {
+    const w = this.worlds.get(id);
+    if (!w) return false;
+    if (w.mode !== mode) {
+      log('info', 'world.mode_set', { id, from: w.mode, to: mode });
+      w.mode = mode;
+    }
+    return true;
+  }
+
   // Idempotent. Returns the world (existing or new), or null if it could not be started —
   // callers must handle null rather than assume a world exists.
   ensure(id: string, mode: WorldMode, ownerAccount?: string): WorldInfo | null {

--- a/server/src/net/http.ts
+++ b/server/src/net/http.ts
@@ -36,6 +36,10 @@ export interface StatusSnapshot {
   requiresPassword: boolean; // a launcher can prompt before connecting
   allowsRegistration: boolean; // false when registration is off OR invite-only
   pvp: boolean;
+  // THE LIVE MODE. The gateway learns a world's mode when it starts the process and never
+  // asked again, so an owner's flip to Party was invisible to the friend-join check, which
+  // refused every friend with not_open. Reported here; the gateway's poll keeps its copy fresh.
+  mode?: 'private' | 'party';
   uptime: number; // seconds
   version: string;
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -180,6 +180,7 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
   // There is no public world. A gateway world boots private (the owner's own game) and the
   // owner flips it to 'party' to admit friends; a standalone stack has no gateway and the
   // account system is its door.
+  let worldBrowserRef: WorldBrowser | undefined; // assigned when the gateway is configured (below)
   let worldMode = opts.worldMode ?? process.env.OMW_WORLD_MODE ?? 'private';
   if (worldMode === 'public') {
     // A stale env or config asking for the deleted mode must not quietly become admit-all.
@@ -660,8 +661,8 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
     // F3: only when a gateway is configured. Without one the Worlds tab reports that this
     // is a standalone world, which is an honest answer and a valid setup.
     ...(config.gateway.url
-      ? { worlds: new WorldBrowser({ gatewayUrl: config.gateway.url,
-          serverToken: config.gateway.serverToken, ownPort: () => port }) }
+      ? { worlds: (worldBrowserRef = new WorldBrowser({ gatewayUrl: config.gateway.url,
+          serverToken: config.gateway.serverToken, ownPort: () => port })) }
       : {}),
   });
   socialRef = social;
@@ -730,6 +731,9 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
       if (mode !== 'private' && mode !== 'party') return 'bad_mode';
       worldMode = mode;
       log('info', 'world.mode_flip', { world: worldId, owner: worldOwner, mode });
+      // The directory is what a friend's join consults (social.ts joinFriend reads the
+      // owner's world mode from it); it must hear this before the owner can say "come in".
+      void worldBrowserRef?.reportMode(worldId, worldOwner, mode);
       // The UI must never GUESS which world it is in. It used to render Solo/Party/Public from
       // a localStorage note of what the player last clicked, which survived reloads and
       // reconnects and so could claim you were somewhere you were not. The server owns this.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1052,6 +1052,7 @@ export async function startServer(opts: StartOptions): Promise<RunningServer> {
     // the whole world now, so this is normally 0 or 1; the gateway's governor still reads it.
     peerCount: simPeers.running,
     pvp: config.rules.pvp,
+    mode: worldMode === 'party' ? 'party' : 'private',
     players: roster.humansInWorld().map((p) => ({
       id: p.id,
       name: p.name,

--- a/server/test/directory.test.ts
+++ b/server/test/directory.test.ts
@@ -410,3 +410,31 @@ test('the multiplayer server hands out the game files the operator uploaded', as
       'a server that does not serve files must not advertise them');
   } finally { await dir2.close(); await h.cleanup(); }
 });
+
+// THE WORLD'S MODE IS THE WORLD'S TO SAY. The directory fixed a world's mode at process start
+// and never asked again, so an owner's flip to Party never reached the friend-join check,
+// which refused every friend with not_open. The world's /status carries the live mode now
+// and the poll adopts it.
+test('directory: an owner flipping to Party is observed by the next poll', async () => {
+  const wdir = mkdtempSync(join(tmpdir(), 'omw-dir-'));
+  let liveMode: 'private' | 'party' = 'private';
+  const worlds = new WorldSupervisor({
+    settings: {
+      worldsDir: wdir, gatewayPort: 8080, serverEntry: '/fake/server.mjs', nodeBin: '/fake/node',
+      basePort: 43000, maxWorlds: 5, idleReapMs: 60_000, startTimeoutMs: 1000, restartBackoffMs: 1000,
+      sharedDir: mkdtempSync(join(tmpdir(), 'omw-shared-')),
+    },
+    spawner: () => new FakeChild() as unknown as ChildProcess,
+    fetchStatus: async (port) => ({ playerCount: 1, connectedCount: 1, maxPlayers: 32, name: `w${port}`, mode: liveMode }),
+  });
+  try {
+    const w = worlds.ensure('priv-alice-x', 'private', 'alice');
+    assert.ok(w);
+    await worlds.poll();
+    assert.equal(worlds.list().find((x) => x.id === 'priv-alice-x')?.mode, 'private');
+    liveMode = 'party'; // the owner flipped, on the world process
+    await worlds.poll();
+    assert.equal(worlds.list().find((x) => x.id === 'priv-alice-x')?.mode, 'party',
+      'the directory still thinks the world is private: every friend join is refused as not_open');
+  } finally { worlds.stopAll(); }
+});

--- a/server/test/directory.test.ts
+++ b/server/test/directory.test.ts
@@ -438,3 +438,21 @@ test('directory: an owner flipping to Party is observed by the next poll', async
       'the directory still thinks the world is private: every friend join is refused as not_open');
   } finally { worlds.stopAll(); }
 });
+
+// ...and the world TELLS the directory the moment it flips, so a friend who clicks join the
+// instant the host says "I'm open" is not refused inside the poll interval. Trusted-server
+// credential only; the named account must be the owner.
+test('directory: a world reports its owner\'s flip and the directory adopts it at once', async () => {
+  const h = await harness();
+  try {
+    const created = await (await fetch(`${h.base}/worlds`, {
+      method: 'POST', headers: { authorization: 'Bearer alice' }, body: JSON.stringify({ id: 'alices-game', mode: 'private', account: 'alice' }),
+    })).json() as { id: string };
+    assert.equal(created.id, 'alices-game');
+    const patch = (auth: string, body: unknown) => fetch(`${h.base}/worlds/alices-game`, { method: 'PATCH', headers: { authorization: auth, 'content-type': 'application/json' }, body: JSON.stringify(body) });
+    assert.equal((await patch('Bearer alice', { mode: 'party', account: 'alice' })).status, 401, 'a player session may not flip a world from outside');
+    assert.equal((await patch('Bearer platform-secret', { mode: 'party', account: 'mallory' })).status, 403, 'a world may only report its own owner');
+    assert.equal((await patch('Bearer platform-secret', { mode: 'party', account: 'alice' })).status, 200);
+    assert.equal(h.worlds.get('alices-game')?.mode, 'party', 'the directory did not adopt the reported flip');
+  } finally { await h.cleanup(); }
+});

--- a/wasm-build/mp-scenarios/s95-play-with-friends.mjs
+++ b/wasm-build/mp-scenarios/s95-play-with-friends.mjs
@@ -128,9 +128,9 @@ export default async function run(ctx) {
         120_000, "the guest arrived in the host's world");
     } catch (e) {
       // The failing waiter is the HOST; what went wrong is on the GUEST. Say what it saw.
-      const gs = await guest.client.eval('JSON.stringify({state: window.omw.state.state, dial: window.omw.state.dialTarget, why: window.omw.state.lastNotice, err: window.omw.state.lastError, detail: window.omw.state.lastErrorDetail, where: window.omw.state.whereNow, social: window.omw.state.socialResult})').catch(() => 'n/a');
+      const gs = await guest.client.eval('JSON.stringify({state: window.omw.state.state, dial: window.omw.state.dialTarget, join: window.omw.state.joinFriendResult, joinTo: window.omw.state.joinFriendTo, err: window.omw.state.lastError, where: window.omw.state.whereNow})').catch(() => 'n/a');
       ctx.log(`guest state at failure: ${gs}`);
-      const tail = (guest.client.logs || []).filter((l) => /\[mp\]|EXC/.test(l)).slice(-25).join(String.fromCharCode(10));
+      const tail = (typeof guest.client.logTail === 'function') ? guest.client.logTail() : 'n/a';
       ctx.log('guest [mp] tail: ' + tail);
       throw e;
     }

--- a/wasm-build/mp-scenarios/s95-play-with-friends.mjs
+++ b/wasm-build/mp-scenarios/s95-play-with-friends.mjs
@@ -123,8 +123,17 @@ export default async function run(ctx) {
     const guestRow =
       `(JSON.parse(window.omw.state.players || '[]')
         .find(function (p) { return p.name === ${JSON.stringify(guestHandle)}; }) || {})`;
-    await host.client.waitFor(`${guestRow}.id !== undefined`,
-      120_000, "the guest arrived in the host's world");
+    try {
+      await host.client.waitFor(`${guestRow}.id !== undefined`,
+        120_000, "the guest arrived in the host's world");
+    } catch (e) {
+      // The failing waiter is the HOST; what went wrong is on the GUEST. Say what it saw.
+      const gs = await guest.client.eval('JSON.stringify({state: window.omw.state.state, dial: window.omw.state.dialTarget, why: window.omw.state.lastNotice, err: window.omw.state.lastError, detail: window.omw.state.lastErrorDetail, where: window.omw.state.whereNow, social: window.omw.state.socialResult})').catch(() => 'n/a');
+      ctx.log(`guest state at failure: ${gs}`);
+      const tail = (guest.client.logs || []).filter((l) => /\[mp\]|EXC/.test(l)).slice(-25).join(String.fromCharCode(10));
+      ctx.log('guest [mp] tail: ' + tail);
+      throw e;
+    }
     ctx.log(`ok: ${guestHandle} is in ${hostHandle}'s world`);
 
     // 6. And they can talk, which is the thing they came for. World chat reaches everyone in


### PR DESCRIPTION
The 09-10 pre-switch mode check read the gateway directory's mode, which was fixed at process spawn — every friend join was refused as `not_open`. Two fixes, both proven live with the native-peer harness: `/status` carries the live mode and the poll adopts it; and the world PATCHes the directory the instant its owner flips (trusted-server only, owner-checked), so a friend who clicks join two seconds after "I'm open" is not refused inside the poll interval. s95 / s100 / s102 PASS live. Refusals now logged server-side and mirrored on the client. Tests added; full suite 1063/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)