### PR TITLE
An operator's stop lasted 400 ms: the owner's own reconnect revived the game

### DIFF
--- a/server/src/gateway/admin.ts
+++ b/server/src/gateway/admin.ts
@@ -262,7 +262,7 @@ export function gatewayAdminRoutes(deps: GatewayAdminDeps): HttpRoute {
         const ctx = await gate(req, res, auth, 'owner');
         if (!ctx) return true;
         if (!deps.worlds.get(id)) { json(res, 404, { error: 'no such game' }); return true; }
-        deps.worlds.stop(id);
+        deps.worlds.stop(id, true); // an operator's stop holds against the owner's redial
         log('warn', 'admin.game_stopped', { by: ctx.accountKey, game: id });
         json(res, 200, { ok: true, message: `stopping ${id}; it comes back when its owner returns` });
         return true;

--- a/server/src/gateway/worlds.ts
+++ b/server/src/gateway/worlds.ts
@@ -537,11 +537,13 @@ export class WorldSupervisor {
   // ban, a config change), short enough that a game stopped by mistake comes back on its own.
   static readonly OPERATOR_STOP_HOLD_MS = 5 * 60_000;
 
-  stop(id: string): void {
+  // `hold`: an OPERATOR's stop is held against revival; the reaper's, the rolling restart's
+  // and shutdown's are not -- an idle-reaped world MUST come back on its owner's next dial.
+  stop(id: string, hold = false): void {
     const w = this.worlds.get(id);
     if (!w) return;
     w.stopping = true;
-    this.blockedUntil.set(id, this.now() + WorldSupervisor.OPERATOR_STOP_HOLD_MS);
+    if (hold) this.blockedUntil.set(id, this.now() + WorldSupervisor.OPERATOR_STOP_HOLD_MS);
     // SIGTERM so the world drains and flushes its stores; main.ts already handles it.
     w.child.kill('SIGTERM');
     // ESCALATE. A world that hangs in its own async shutdown never fires 'exit', and 'exit' is

--- a/server/src/gateway/worlds.ts
+++ b/server/src/gateway/worlds.ts
@@ -530,10 +530,18 @@ export class WorldSupervisor {
     this.pollTimer.unref();
   }
 
+  // How long an OPERATOR's stop holds against revival. The owner's client is still connected
+  // when the operator stops their game; its reconnect backoff redials within a second and
+  // the front door revives the world on dial -- measured: stopped at :17.9, started again at
+  // :18.3. A stop that lasts 400 ms is not a stop. Long enough for the operator to act (a
+  // ban, a config change), short enough that a game stopped by mistake comes back on its own.
+  static readonly OPERATOR_STOP_HOLD_MS = 5 * 60_000;
+
   stop(id: string): void {
     const w = this.worlds.get(id);
     if (!w) return;
     w.stopping = true;
+    this.blockedUntil.set(id, this.now() + WorldSupervisor.OPERATOR_STOP_HOLD_MS);
     // SIGTERM so the world drains and flushes its stores; main.ts already handles it.
     w.child.kill('SIGTERM');
     // ESCALATE. A world that hangs in its own async shutdown never fires 'exit', and 'exit' is

--- a/server/test/worlds.test.ts
+++ b/server/test/worlds.test.ts
@@ -172,6 +172,23 @@ test('worlds: a crash backs off instead of hot-looping', () => {
   assert.ok(sup.ensure('crashy', 'private'), 'but it comes back after the backoff');
 });
 
+// An operator's stop must be a stop. The owner's client is still connected and redials within
+// a second; the front door revives a private world on dial (ensure), so without a hold the
+// game was back 400 ms after it was stopped. The hold is the same instrument as crash backoff.
+test('worlds: an operator stop holds against revival, then the world may come back', async () => {
+  const { sup, spawned, advance } = harness();
+  sup.ensure('w', 'private', 'alice');
+  sup.stop('w');
+  await tick();
+  spawned[0]!.child.emit('exit', 0, 'SIGTERM');
+  await tick();
+  assert.equal(sup.ensure('w', 'private', 'alice'), null, 'revived on the next dial: the stop lasted no time at all');
+  advance(4 * 60_000);
+  assert.equal(sup.ensure('w', 'private', 'alice'), null, 'still held four minutes in');
+  advance(2 * 60_000);
+  assert.ok(sup.ensure('w', 'private', 'alice'), 'a game stopped by mistake comes back on its own after the hold');
+});
+
 test('worlds: a stale exit cannot evict the world that replaced it, and frees no live port', async () => {
   const { sup, spawned, advance } = harness();
   sup.ensure('w', 'private');
@@ -179,6 +196,8 @@ test('worlds: a stale exit cannot evict the world that replaced it, and frees no
   sup.stop('w');
   await tick();
   advance(20_000);
+  assert.equal(sup.ensure('w', 'private'), null, 'an operator stop holds against revival');
+  advance(5 * 60_000);
   sup.ensure('w', 'private');
   assert.equal(spawned.length, 2);
   first.emit('exit', 0, 'SIGTERM'); // the OLD process's exit arrives late

--- a/server/test/worlds.test.ts
+++ b/server/test/worlds.test.ts
@@ -178,7 +178,7 @@ test('worlds: a crash backs off instead of hot-looping', () => {
 test('worlds: an operator stop holds against revival, then the world may come back', async () => {
   const { sup, spawned, advance } = harness();
   sup.ensure('w', 'private', 'alice');
-  sup.stop('w');
+  sup.stop('w', true);
   await tick();
   spawned[0]!.child.emit('exit', 0, 'SIGTERM');
   await tick();
@@ -193,7 +193,7 @@ test('worlds: a stale exit cannot evict the world that replaced it, and frees no
   const { sup, spawned, advance } = harness();
   sup.ensure('w', 'private');
   const first = spawned[0]!.child;
-  sup.stop('w');
+  sup.stop('w', true);
   await tick();
   advance(20_000);
   assert.equal(sup.ensure('w', 'private'), null, 'an operator stop holds against revival');


### PR DESCRIPTION
Caught live by s101 under the harness. `stop()` now holds the world against revive-on-dial for five minutes (same `blockedUntil` instrument as crash backoff); the player's client gets the honest 502 and keeps retrying. Test added; worlds suite 25/25; full suite before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)