### PR TITLE
An item a friend handed you could not be handed on

### DIFF
--- a/openmw/files/data/scripts/mp/objects.lua
+++ b/openmw/files/data/scripts/mp/objects.lua
@@ -39,6 +39,7 @@ local CONTAINER_OPEN_DELAY = 0.2
 local ECHO_GUARD_SECONDS = 5
 
 local netActorCount = 0 -- runtime actors built here from the holder's naming (mirror: netActors)
+local recentTakes = {} -- netId -> realTime of our granted take (its delete echo is ours)
 local netToObj = {} -- netId -> GameObject
 local objIdToNet = {} -- obj.id (string) -> netId
 local netSpawned = {} -- obj.id -> true (objects created FROM the network or net-acked)
@@ -686,7 +687,12 @@ end
 handlers.MP_ObjectDelete = function(data)
     local obj = resolveBody(data)
     if not obj then return end
-    if isOwnEcho(data) or recentPickups[obj.id] then return end
+    -- OUR OWN TAKE'S ECHO is the delete for the NET ID we took, not for the object. The
+    -- object outlives the take (it moves into our inventory), and if we drop it again it is
+    -- placed under a NEW net id -- a delete naming that one is a friend picking it up, which
+    -- keyed on the object id read as our stale echo and left the item lying on our screen
+    -- after they had it in their pocket. Trading back within the guard window did exactly this.
+    if isOwnEcho(data) or (data.net ~= nil and recentTakes[data.net]) then return end
     local netId = objIdToNet[obj.id]
     if netId then
         netToObj[netId] = nil
@@ -717,9 +723,10 @@ handlers.MP_ObjectTakeResult = function(data)
     local player = deps.playerFn()
     local obj = op.obj
     if not player or not obj or not obj:isValid() then return end
-    recentPickups[obj.id] = core.getRealTime() -- our own ObjectDelete echo must not remove it twice
+    recentPickups[obj.id] = core.getRealTime() -- the cell frame's deleted list must not remove it twice
     local netId = objIdToNet[obj.id]
     if netId then
+        recentTakes[netId] = core.getRealTime() -- our own ObjectDelete echo, by the id it names
         netToObj[netId] = nil
         objIdToNet[obj.id] = nil
     end
@@ -1074,6 +1081,9 @@ function objects.tick(now)
 
     for id, t in pairs(recentPickups) do
         if now - t > ECHO_GUARD_SECONDS then recentPickups[id] = nil end
+    end
+    for id, t in pairs(recentTakes) do
+        if now - t > ECHO_GUARD_SECONDS then recentTakes[id] = nil end
     end
 
     for opId, op in pairs(pendingOps) do

--- a/openmw/files/data/scripts/mp/objects.lua
+++ b/openmw/files/data/scripts/mp/objects.lua
@@ -723,6 +723,11 @@ handlers.MP_ObjectTakeResult = function(data)
         netToObj[netId] = nil
         objIdToNet[obj.id] = nil
     end
+    -- ONCE IT IS IN OUR POCKET IT IS OURS TO DROP. An item that ARRIVED from the net was
+    -- marked so its own ObjectPlace could never read as a local drop -- and the mark followed
+    -- the object into the inventory, so dropping it again was ignored as that same echo. An
+    -- item a friend handed you could not be handed on; trading stopped after one hop.
+    netSpawned[obj.id] = nil
     -- The genuine ActionTake: itemTaken (crime), inventory add, world delete.
     pcall(function() world._runStandardActivationAction(obj, player) end)
 end

--- a/wasm-build/mp-scenarios/s108-trade.mjs
+++ b/wasm-build/mp-scenarios/s108-trade.mjs
@@ -1,0 +1,58 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s108: TRADING BETWEEN PLAYERS. The sanctioned exchange is a drop and a pickup (activating a
+// friend's body is refused on purpose: their puppet's inventory is a per-screen copy). Two
+// players, two directions: A drops an item, B takes it and now HOLDS it; B drops gold, A
+// takes it and now holds the gold -- and nothing is duplicated or lost on either screen.
+//
+// s79 proves the contested case (both grab, one wins). This proves the ordinary one: the
+// item that changes hands is in exactly one inventory afterwards, and it is the recipient's.
+import assert from 'node:assert/strict';
+
+const STEP = 30_000;
+const netCount = 'Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length';
+
+async function countOf(c, id) {
+  await c.eval("if (window.omw.state) window.omw.state.count = null; 'cleared';");
+  await c.cmd(`count:${id}`);
+  await c.waitFor("typeof window.omw.state.count === 'string'", 10_000, `${c.name} reported its count`);
+  return Number(await c.eval('window.omw.state.count'));
+}
+
+async function handOver(ctx, giver, taker, itemId, what) {
+  const before = await countOf(taker, itemId);
+  await giver.cmd(`drop:${itemId}`);
+  await giver.waitFor(`${netCount} === 1`, STEP, `${giver.name} tracks its drop of ${what}`);
+  await taker.waitFor(`${netCount} === 1`, STEP, `${taker.name} sees the ${what} on the ground`);
+  const netId = await taker.eval('Object.keys(JSON.parse(window.omw.state.netObjects))[0]');
+  await taker.cmd(`takenet:${netId}`);
+  await taker.waitFor(`${netCount} === 0`, STEP, `the ${what} left the world on ${taker.name}`);
+  await giver.waitFor(`${netCount} === 0`, STEP, `the ${what} left the world on ${giver.name}`);
+  await ctx.sleep(1_500);
+  const g = await countOf(giver, itemId);
+  const t = await countOf(taker, itemId);
+  ctx.log(`${what}: ${giver.name} holds ${g}, ${taker.name} holds ${t} (had ${before})`);
+  assert.equal(g, 0, `${giver.name} still holds the ${what} it gave away`);
+  assert.equal(t, before + 1, `${taker.name} did not receive the ${what}`);
+}
+
+export default async function run(ctx) {
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a'), ctx.launchClient('bot-b')]);
+  for (const c of [a, b]) {
+    await c.waitFor('window.omw.state.state === "Joined"', 60_000, `${c.name} joined`);
+  }
+
+  // A hands B a test item.
+  await a.cmd('equiptest');
+  await a.waitFor('(window.omw.state.equippedIds||"") !== ""', 12_000, 'A holds the test item');
+  const itemId = (await a.eval('window.omw.state.equippedIds')).split(',')[0];
+  assert.ok(itemId, 'test item id');
+  await handOver(ctx, a, b, itemId, 'test item');
+
+  // B hands it back: the recipient can give it on, which is what a trade needs.
+  await handOver(ctx, b, a, itemId, 'test item (returned)');
+
+  const errs = a.luaErrors().concat(b.luaErrors());
+  assert.equal(errs.length, 0, 'Lua errors during the trade:\n' + errs.join('\n'));
+  ctx.log('ok: an item changed hands both ways, in exactly one inventory at every step');
+}


### PR DESCRIPTION
Found by the new s108 trade scenario under the native-peer harness, two defects: (1) a received item kept its "arrived from the net" mark into the inventory, so re-dropping it was ignored as an echo; (2) our own take's delete echo was guarded by OBJECT id, so a friend taking the item we re-dropped (new net id) read as our stale echo and left a ghost on our screen. Both fixed; s108 PASS on the rebuilt engine, s79/s30 still green. Lua runner 110/110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)