### PR TITLE
Gameplay pass: two players kill a wild creature (spawn gate off from the first frame)

### DIFF
--- a/openmw/apps/openmw/mwmp/puppets.cpp
+++ b/openmw/apps/openmw/mwmp/puppets.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <map>
 
 #include <components/debug/debuglog.hpp>
@@ -237,7 +238,13 @@ namespace MWMP
     {
         bool& localSummons()
         {
-            static bool v = true;
+            // OFF FROM THE FIRST FRAME ON A MULTIPLAYER CLIENT. The Lua side used to switch this
+            // off once the server said "this world is simulated" -- but the starting cells load
+            // (and their levelled lists roll) while the socket is still connecting, so every
+            // client began the game with a private, unhittable copy of each wild creature near
+            // the spawn point, standing beside the peer's real one. The sim peer (OPENMW_MP_SYSTEM)
+            // is the process that rolls them; singleplayer has no URL and keeps vanilla.
+            static bool v = !(std::getenv("OPENMW_MP_URL") != nullptr && std::getenv("OPENMW_MP_SYSTEM") == nullptr);
             return v;
         }
     }

--- a/openmw/files/data/scripts/mp/combat.lua
+++ b/openmw/files/data/scripts/mp/combat.lua
@@ -48,6 +48,8 @@ function combat.onPuppetHit(data)
     -- s51/s58 as its regression guard; magic (onPuppetSpellHit) is unaffected -- the avatar
     -- does not cast. Degraded mode (no peer) means no melee until the peer returns, by design.
     if not data.mpTest then return end
+    -- Mirror for the scenarios: which address a test swing went out under, or why it did not.
+    local function fwd(why) pcall(function() mp.set('hitFwd', why) end) end
     local target
     if data.playerId then
         -- Player victim. PvP off: cancel silently — the server drops these anyway, but
@@ -61,6 +63,7 @@ function combat.onPuppetHit(data)
         if not cellKey then
             -- Nothing to address the target with. Rare, and genuinely undeliverable.
             print('[mp] combat: victim has no cell, hit not forwarded')
+            fwd('no-cell')
             return
         end
         -- THE EPOCH IS OPTIONAL ON THE WIRE, AND THIS USED TO REFUSE TO SEND WITHOUT ONE.
@@ -96,6 +99,7 @@ function combat.onPuppetHit(data)
     if data.weaponId then body.weaponId = data.weaponId end
     if data.ammoId then body.ammoId = data.ammoId end
     if data.hitPos then body.hitPos = data.hitPos end
+    fwd(target.net and ('net:' .. tostring(target.net)) or (target.playerId and 'player' or 'ref'))
     mp.sendEvent('CombatHit', body)
 end
 
@@ -198,6 +202,12 @@ end
 combat.handlers.MP_CombatHit = function(data)
     creditThreat(data)
     local victim = resolveVictim(data)
+    if mp.isSystem and mp.isSystem() then
+        local t = data.target or {}
+        print(string.format('[mp] CombatHit on peer: net=%s ref=%s cell=%s resolved=%s',
+            tostring(t.net), tostring(t.ref and t.ref.recordId), tostring(t.cellKey),
+            victim and tostring(victim.recordId) or 'NO'))
+    end
     if not victim then return end
     local info = attackInfoFrom(data)
     -- Re-emit the STOCK Hit event: scripts/omw/combat/interface.lua turns it into

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -834,7 +834,10 @@ end
 -- creature is the one that engages and is relayed to everyone -- so while a holder simulates
 -- our cell the engine must not spawn a local copy too (mwmp/puppets.hpp setLocalSummons).
 -- Re-evaluated as the holder comes and goes; degraded mode (no peer) keeps local summons.
-local localSummonsOn = true
+-- Mirrors the engine's own default (mwmp/puppets.cpp): a human multiplayer client starts
+-- with local spawns OFF, before the first cell loads; only a confirmed degraded world (joined,
+-- nobody simulating) turns them on.
+local localSummonsOn = not (mp.isEnabled() and not (mp.isSystem and mp.isSystem()))
 local localSpawnsDbgAt = 0
 local localSpawnsGuardSaid = false
 local function localSummonsTick()
@@ -842,6 +845,7 @@ local function localSummonsTick()
         localSpawnsGuardSaid = true
         pcall(function() mp.set('localSpawnsBind', tostring(mp.setLocalSpawns ~= nil) .. '/' .. tostring(mp.setLocalSummons ~= nil)) end)
         print('[mp] localSpawns guard: setLocalSpawns=' .. tostring(mp.setLocalSpawns) .. ' setLocalSummons=' .. tostring(mp.setLocalSummons))
+        pcall(function() mp.set('localSpawns', localSummonsOn and 'on' or 'off') end) -- scenario mirror
     end
     if (mp.isSystem and mp.isSystem()) or not (mp.setLocalSpawns or mp.setLocalSummons) then return end
     -- STICKY on "this world is simulated": levelled lists roll at cell load, before the new
@@ -849,7 +853,10 @@ local function localSummonsTick()
     -- creature in every cell we enter and then learn better. Once any holder has been seen the
     -- peer is the one spawning; only a peer outage (every holder gone) hands it back to us.
     local simulated = net.state == 'Joined' and net.flags and net.flags.simulated == true
-    local want = not (simulated or actors.hasHolder(ownCellKeyCache) or actors.anyHolder())
+    -- Not joined yet is not "degraded": the socket is still connecting while the starting
+    -- cells load, and a creature rolled in that window is a ghost only this screen can see.
+    local want = net.state == 'Joined'
+        and not (simulated or actors.hasHolder(ownCellKeyCache) or actors.anyHolder())
     -- Diagnostic mirror (s107): why local spawns are on or off, once a second.
     local nowD = core.getRealTime()
     if nowD - (localSpawnsDbgAt or 0) >= 1 then
@@ -2288,14 +2295,25 @@ local eventHandlers = {
             local p = puppets[data.playerId]
             victim = p and p.obj:isValid() and p.obj or nil
         elseif data.record then
+            -- Several bodies can share a record (two scribs in one cell): prefer the one we
+            -- puppet -- the body everyone sees -- over a local-only twin, like a real swing at
+            -- the creature in front of the player would.
             for _, obj in ipairs(world.activeActors) do
-                if obj:isValid() and obj.recordId == data.record then victim = obj break end
+                if obj:isValid() and obj.recordId == data.record then
+                    if actors.isPuppetedActor(obj) then victim = obj break end
+                    victim = victim or obj
+                end
             end
         end
         if not victim then
             print('[mp] mpTestHit: no victim for ' .. json.encode(data))
             return
         end
+        -- Which body the hook chose: a scenario that fails "hits do nothing" needs to know
+        -- whether it swung at the puppet everyone else sees, or at a local twin.
+        print(string.format('[mp] mpTestHit: %s id=%s content=%s net=%s puppeted=%s',
+            tostring(victim.recordId), tostring(victim.id), tostring(victim.contentFile),
+            tostring(objects.netIdOf(victim)), tostring(actors.isPuppetedActor(victim))))
         -- WHICH DAMAGE CHANNEL. The engine fills EITHER health OR fatigue and never both
         -- (mwlua/luamanagerimp.cpp onHit), and an UNARMED blow in Morrowind is a fatigue hit.
         -- This hook used to hardcode health, which is precisely why the suite could not catch

--- a/openmw/files/data/scripts/mp/puppet.lua
+++ b/openmw/files/data/scripts/mp/puppet.lua
@@ -189,6 +189,10 @@ end
 -- PRE-mitigation damage to the victim's owner, and returns false to cancel the entire local
 -- chain. Nothing is applied here: armor/difficulty/sounds belong to the owner's engine.
 local function onHitIntercept(attack)
+    if attack.mpTest then
+        print(string.format('[mp] puppet intercept: %s key=%s pid=%s', tostring(self.object.recordId),
+            tostring(actorKey), tostring(playerId)))
+    end
     if not playerId and not actorKey then return end -- not a live puppet: let the engine be
     local weapon = attack.weapon
     core.sendGlobalEvent('mpCombatHit', {

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -19,7 +19,10 @@ Run locally under `wasm-build/Dockerfile.harness-peer` with `OMW_SIM_PEER_BIN` s
 engine built from the same tree. PASS: s22 (death seen by the other player), s67 (avatar
 swing), s77 (death -> respawn), s31 (shared container), s32 (doors), s58 (melee forward),
 s59 (spell forward), s78 (crime pursuit), s79 (pickup race), s51 (NPC combat), s107 (runtime
-creatures named once, built on both clients), s95 (play with friends -- FAILED first: every
+creatures named once, built on both clients), s108 (trade both ways, one inventory at every
+step), s109 (two players kill a peer-named wild creature -- FAILED first: every client rolled
+a private ghost of each creature near the spawn before the spawn gate was down; fixed the
+same day, engine default + Lua), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/wasm-build/mp-scenarios/s109-fight-wild.mjs
+++ b/wasm-build/mp-scenarios/s109-fight-wild.mjs
@@ -47,6 +47,20 @@ export default async function run(ctx) {
     died = (await a.eval(deadExpr)) === true || (await b.eval(deadExpr)) === true;
   }
   ctx.log(`hitFwd A=${await a.eval('window.omw.state.hitFwd')} B=${await b.eval('window.omw.state.hitFwd')}`);
+  ctx.log('A luaErrors: ' + a.luaErrors().slice(-5).join(' || '));
+  // Which body the hook swung at. A "content=nil net=nil puppeted=false" line here is a
+  // LOCAL GHOST: a creature this screen rolled itself (levelled list before the spawn gate
+  // was down), standing beside the peer's real one and unhittable by anyone.
+  const hitTail = (a.logTail ? a.logTail(2000) : '').split(String.fromCharCode(10)).filter((l) => /mpTestHit|puppet intercept/.test(l)).slice(-4);
+  ctx.log('A hit tail: ' + hitTail.join(' || '));
+  ctx.log(`localSpawns A=${await a.eval('window.omw.state.localSpawns')} dbg=${await a.eval('window.omw.state.localSpawnsDbg')} bind=${await a.eval('window.omw.state.localSpawnsBind')}`);
+  ctx.log(`A census=${await a.eval('window.omw.state.actorCensus')}`);
+  ctx.log(`A puppetedActors=${await a.eval('window.omw.state.puppetedActors')} actorCount=${await a.eval('window.omw.state.actorCount')}`);
+  ctx.log(`A netObjects=${await a.eval('window.omw.state.netObjects')} netActors=${await a.eval('window.omw.state.netActors')}`);
+  const mpLines = (a.logTail ? a.logTail(400) : '').split(String.fromCharCode(10)).filter((l) => /\[mp\]/.test(l) && !/session state|journal|Local map/.test(l)).slice(-30);
+  ctx.log('A [mp] tail: ' + mpLines.join(' || '));
+  const fwdA = String(await a.eval('window.omw.state.hitFwd'));
+  assert.ok(fwdA.startsWith('net:'), `A's swing did not go out under a net id (hitFwd=${fwdA}): it hit a local ghost or nothing`);
   assert.ok(died, `the ${victim} never died: hits on a NAMED runtime creature are not reaching the peer, `
     + 'or the peer cannot resolve the net id to its own creature -- see the peer tail below');
   await a.waitFor(deadExpr, STEP, 'A sees it dead');

--- a/wasm-build/mp-scenarios/s109-fight-wild.mjs
+++ b/wasm-build/mp-scenarios/s109-fight-wild.mjs
@@ -1,0 +1,57 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s109: TWO PLAYERS KILL A WILD CREATURE. The most common fight in the game is against a
+// levelled-list creature -- and since s107 those are NAMED runtime actors (the peer's, addressed
+// by net id), not content refs like the NPCs s51 hits. s51 picks its victim from the probe and
+// happened to pick a mudcrab once, and the mudcrab never died. This targets a net actor BY
+// CONSTRUCTION: both clients snap into open country, wait for the peer to name a creature, hit
+// the one both can see, and it must die -- once, for both -- through the hit chain that
+// addresses it by net id at every hop (client puppet -> server -> peer -> the creature).
+import assert from 'node:assert/strict';
+
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const SPOT = '-12500,-53100,512'; // inside -2,-7, where the live run named scrib / kwama forager
+
+const netObjs = async (c) => JSON.parse(await c.eval('window.omw.state.netObjects||"{}"'));
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-7');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  await a.cmd('snapto:' + SPOT);
+  await b.cmd('snapto:' + SPOT);
+
+  // A creature the peer named, built on both screens.
+  await a.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'A built a named creature');
+  await b.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'B built a named creature');
+  const oa = await netObjs(a), ob = await netObjs(b);
+  const shared = Object.keys(oa).find((id) => ob[id] === oa[id]);
+  assert.ok(shared, `no creature both clients agree on: A=${JSON.stringify(oa)} B=${JSON.stringify(ob)}`);
+  const victim = oa[shared];
+  ctx.log(`both clients attacking the peer's "${victim}" (net ${shared})`);
+
+  // Both puppeted it (the non-holder sweep), so the interceptor is armed on both.
+  for (const c of [a, b]) {
+    await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', STEP, `${c.name} puppeted the cell actors`);
+  }
+
+  const deadExpr = `((JSON.parse(window.omw.state.actorProbe||"{}")[${JSON.stringify(victim)}]||{}).dead === true)`;
+  const deadline = Date.now() + 90_000;
+  let died = false;
+  while (Date.now() < deadline && !died) {
+    await a.cmd(`hitn:${victim}:40`);
+    await b.cmd(`hitn:${victim}:40`);
+    await ctx.sleep(600);
+    died = (await a.eval(deadExpr)) === true || (await b.eval(deadExpr)) === true;
+  }
+  ctx.log(`hitFwd A=${await a.eval('window.omw.state.hitFwd')} B=${await b.eval('window.omw.state.hitFwd')}`);
+  assert.ok(died, `the ${victim} never died: hits on a NAMED runtime creature are not reaching the peer, `
+    + 'or the peer cannot resolve the net id to its own creature -- see the peer tail below');
+  await a.waitFor(deadExpr, STEP, 'A sees it dead');
+  await b.waitFor(deadExpr, STEP, 'B sees it dead');
+  const pa = await probeOf(a), pb = await probeOf(b);
+  assert.equal(pa[victim]?.dead, true); assert.equal(pb[victim]?.dead, true);
+  ctx.log(`ok: the peer's ${victim} died once, for both players`);
+}


### PR DESCRIPTION
## What
s109 (two players kill a peer-named levelled creature) failed: every swing landed on a scrib with no net id and no puppet, a **local ghost**. The client's spawn gate only went down once the server said "simulated", but the starting cells (and their levelled lists) load while the socket is still connecting. Every player started with a private, unhittable twin of each wild creature near the spawn point, next to the peer's real one.

## Fix
- `mwmp/puppets.cpp`: a human multiplayer client starts with local spawns OFF from the first frame (sim peer and singleplayer unchanged).
- `global.lua`: the Lua belief matches; "not joined yet" no longer reads as degraded mode; initial state mirrored for scenarios.
- `mpTestHit` prefers a puppeted body when several share a record (what a swing at the creature in front of you does) and prints the body it chose; `puppet.lua` prints test-hook interceptions.
- s109 asserts the swing went out under a net id.
- Coverage map: s108/s109 recorded as live evidence.

## Gates
- s109 PASS (peer's scrib dies once, for both players); s51, s58, s59, s107, s108 PASS on the same engine.
- tsc clean; server suite 1070 tests, 0 fail; Lua logic runner 110/110; native peer compile (tier2-check) OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)