### PR TITLE
Gameplay pass: the creature bites back, loot the kill, heals and casts stick, the avatar gets the player's stats

### DIFF
--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -402,12 +402,8 @@ actors.handlers.MP_ActorAuthorityGrant = function(data)
                 obj:teleport(cellArg, util.vector3(a.x, a.y, a.z),
                     { rotation = util.transform.rotateZ(a.rotZ or 0) })
             end)
-            pcall(function()
-                local d = types.Actor.stats.dynamic
-                if a.hp then d.health(obj).base = a.hp.b; d.health(obj).current = a.hp.c end
-                if a.mp then d.magicka(obj).base = a.mp.b; d.magicka(obj).current = a.mp.c end
-                if a.ft then d.fatigue(obj).base = a.ft.b; d.fatigue(obj).current = a.ft.c end
-            end)
+            -- Self-gated write: the actor's own script (companion.lua mpSetStats) applies it.
+            pcall(function() obj:sendEvent('mpSetStats', { hp = a.hp, mp = a.mp, ft = a.ft }) end)
         end
     end
     print('[mp] actor authority GRANTED for ' .. cellKey .. ' epoch ' .. tostring(data.epoch))

--- a/openmw/files/data/scripts/mp/avatar.lua
+++ b/openmw/files/data/scripts/mp/avatar.lua
@@ -136,6 +136,35 @@ return {
         end,
     },
     eventHandlers = {
+        -- The owner's character, applied to this body: the doc on spawn (global.lua
+        -- applyAvatarDoc), a client heal or spend later (MP_AvatarRestore). Stat setters
+        -- are Self-gated in mwlua/stats.cpp, so this is the only place they can land.
+        mpAvatarStats = function(stats)
+            if type(stats) ~= 'table' then return end
+            local okL, errL = pcall(function()
+                if stats.level then types.Actor.stats.level(self).current = stats.level end
+                for name, v in pairs(stats.attributes or {}) do
+                    local a = types.Actor.stats.attributes[name]
+                    if a then a(self).base = v end
+                end
+                if types.NPC.objectIsInstance(self) then
+                    for name, v in pairs(stats.skills or {}) do
+                        local s = types.NPC.stats.skills[name]
+                        if s then s(self).base = v end
+                    end
+                end
+                local map = { hp = 'health', mp = 'magicka', ft = 'fatigue' }
+                for k, statName in pairs(map) do
+                    local d = stats.dynamic and stats.dynamic[k]
+                    if d then
+                        local stat = types.Actor.stats.dynamic[statName](self)
+                        if d.b then stat.base = d.b end
+                        if d.c then stat.current = d.c end
+                    end
+                end
+            end)
+            if not okL then print('[mp] avatar stats apply failed: ' .. tostring(errL)) end
+        end,
         mpAvatarPolicy = function(data)
             if data.pvp ~= nil then pvpEnabled = data.pvp == true end
             if type(data.avatarObjIds) == 'table' then avatarObjIds = data.avatarObjIds end

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -114,4 +114,26 @@ return {
             core.sendGlobalEvent('mpActorFollow', { actor = self.object, target = target, escort = escort })
         end,
     },
+    eventHandlers = {
+        -- THE BARS A HANDOFF HANDS US. Dynamic-stat setters are Self-gated (mwlua/stats.cpp),
+        -- so the holder cannot write a snapshot's health onto an actor from the global script
+        -- -- it threw inside a pcall, and every actor a new holder took over came back at
+        -- whatever health its own engine had, a half-dead bandit at full. This script is on
+        -- every NPC and creature already, so the write lands here.
+        mpSetStats = function(dyn)
+            if type(dyn) ~= 'table' then return end
+            pcall(function()
+                local d = types.Actor.stats.dynamic
+                local map = { hp = 'health', mp = 'magicka', ft = 'fatigue' }
+                for k, statName in pairs(map) do
+                    local v = dyn[k]
+                    if v then
+                        local stat = d[statName](self)
+                        if v.b then stat.base = v.b end
+                        if v.c then stat.current = v.c end
+                    end
+                end
+            end)
+        end,
+    },
 }

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2257,7 +2257,10 @@ local eventHandlers = {
             if item.recordId == data.id then
                 -- Native transfer only: the container watch (armed by chest:open) diffs the
                 -- inventory change into the ContainerOpRequest — the same path a UI put takes.
-                item:moveInto(types.Container.content(chestObj))
+                -- A corpse keeps its loot in Actor.inventory, a chest in Container.content.
+                local store = types.Actor.objectIsInstance(chestObj) and types.Actor.inventory(chestObj)
+                    or types.Container.content(chestObj)
+                item:moveInto(store)
                 return
             end
         end
@@ -2266,6 +2269,12 @@ local eventHandlers = {
     -- Open the chest formally (ContainerOpen with a contents snapshot; the first opener's
     -- snapshot becomes canonical server-side).
     mpChestOpen = function(data)
+        -- A NET ID names any lootable body: the test chest, or a corpse the peer named
+        -- (s111). Adopt it as the chest so chest:put / chesttake work on it too.
+        if data and data.netId then
+            local o = objects.objOfNet(data.netId)
+            if o and o:isValid() then chestObj = o end
+        end
         if chestObj and chestObj:isValid() then
             objects.onActivate(chestObj, playerScript())
         elseif data and data.netId then

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -463,30 +463,12 @@ local function applyAvatarDoc(id)
     -- pursued on sight instead of only after their next offence.
     if mp.setAvatarBounty then pcall(function() mp.setAvatarBounty(obj, doc.bounty or 0) end) end
     -- Stats first: a fight against a default-statted mannequin is the bug this fixes.
-    pcall(function()
-        local stats = doc.stats or {}
-        if stats.level then types.Actor.stats.level(obj).current = stats.level end
-        for name, v in pairs(stats.attributes or {}) do
-            local a = types.Actor.stats.attributes[name]
-            if a then a(obj).base = v end
-        end
-        for name, v in pairs(stats.skills or {}) do
-            local s = types.NPC.stats.skills[name]
-            if s then s(obj).base = v end
-        end
-        local dyn = stats.dynamic
-        if dyn then
-            local map = { hp = 'health', mp = 'magicka', ft = 'fatigue' }
-            for k, statName in pairs(map) do
-                local d = dyn[k]
-                if d then
-                    local stat = types.Actor.stats.dynamic[statName](obj)
-                    if d.b then stat.base = d.b end
-                    if d.c then stat.current = d.c end
-                end
-            end
-        end
-    end)
+    -- IN THE AVATAR'S OWN SCRIPT. Every stat setter in mwlua/stats.cpp is Self-gated
+    -- ("Allowed only in local scripts for 'openmw.self'"); writing them from here threw on
+    -- the first line, and the pcall that used to wrap this block swallowed it -- so the
+    -- avatar stayed the level-1 template it was built from: attributes, skills, level and
+    -- the HEALTH POOL. A level-20 player's avatar had a level-1 body's bars.
+    pcall(function() obj:sendEvent('mpAvatarStats', doc.stats or {}) end)
     for _, sid in ipairs(doc.spells or {}) do
         pcall(function() types.Actor.spells(obj):add(sid) end)
     end
@@ -1735,13 +1717,10 @@ local eventHandlers = {
         if not (mp.isSystem and mp.isSystem()) or not data or not data.id then return end
         local p = puppets[data.id]
         if not p or not p.obj or not p.obj:isValid() then return end
-        pcall(function()
-            local d = types.Actor.stats.dynamic
-            local map = { hp = 'health', mp = 'magicka', ft = 'fatigue' }
-            for k, statName in pairs(map) do
-                if data[k] and data[k].c then d[statName](p.obj).current = data[k].c end
-            end
-        end)
+        -- Self-gated write (see applyAvatarDoc): the avatar's script applies it. Done from
+        -- here it threw inside a pcall, and no potion, rest or self-heal ever reached the
+        -- avatar -- the next report undid every one of them (s112).
+        pcall(function() p.obj:sendEvent('mpAvatarStats', { dynamic = { hp = data.hp, mp = data.mp, ft = data.ft } }) end)
     end,
 
     -- Phase 3: a player's input frame, routed to the avatar that embodies them. Only the

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -161,7 +161,10 @@ local tracked = {
     mp = { stat = 'magicka', gainsOnly = false },
 }
 for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
+local peerBarsAt = nil -- when the peer last reported; past PEER_RULES_S our own bars rule again
+local PEER_RULES_S = 5 -- server/src/core/players.ts INPUT_DRIVING_MS, the same predicate
 function identity.notePeerBars(hp, mpv, ft)
+    peerBarsAt = core.getRealTime()
     local v = { hp = hp, mp = mpv, ft = ft }
     for k, t in pairs(tracked) do
         if v[k] ~= nil then
@@ -342,18 +345,28 @@ function identity.tick(now)
         nextAt.dynamic = now + INTERVALS.dynamic
         local dyn = snapDynamic()
         mp.set('hp', tostring(dyn.hp.c)) -- mirror unconditionally (diff may be seeded)
-        for k, t in pairs(tracked) do
-            if t.peer and math.abs(t.delta) > 0.5 and not dead then
-                -- Claim the local change on top of what the peer last said, not on top of
-                -- whatever the bar shows this frame (which a report may have just reset).
-                dyn[k].c = math.floor(math.max(0, math.min(dyn[k].b, t.peer + t.delta)) + 0.5)
+        if peerBarsAt and now - peerBarsAt < PEER_RULES_S and not dead then
+            -- THE PEER RULES OUR BARS: send only what we changed, on top of what the peer
+            -- last said -- never a bar we merely echo from its report. An echoed report the
+            -- peer has since overtaken (a bite landed, a spend applied) would be taken as a
+            -- fresh claim: the bite undone, the cast refilled (s113).
+            local claim, any = {}, false
+            for k, t in pairs(tracked) do
+                if math.abs(t.delta) > 0.5 then
+                    claim[k] = { c = math.floor(math.max(0, math.min(dyn[k].b, t.peer + t.delta)) + 0.5), b = dyn[k].b }
+                    any = true
+                end
+                t.delta = 0
             end
-            t.delta = 0
-        end
-        local fp = fingerprint(dyn)
-        if fp ~= last.dynamic then
-            last.dynamic = fp
-            mp.sendEvent('PlayerStatsDynamic', dyn)
+            if any then mp.sendEvent('PlayerStatsDynamic', claim) end
+            last.dynamic = nil -- the next full snapshot (peer gone) must send unconditionally
+        else
+            for _, t in pairs(tracked) do t.delta = 0 end
+            local fp = fingerprint(dyn)
+            if fp ~= last.dynamic then
+                last.dynamic = fp
+                mp.sendEvent('PlayerStatsDynamic', dyn)
+            end
         end
     end
 
@@ -458,6 +471,7 @@ end
 function identity.reset()
     last = {}
     for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
+    peerBarsAt = nil
     -- nil, NOT {}: the next pass must re-seed the baseline rather than treat the whole restored
     -- inventory as newly acquired.
     acqCounts = nil

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -144,6 +144,27 @@ local function snapDynamic()
     return { hp = stat(d.health(self)), mp = stat(d.magicka(self)), ft = stat(d.fatigue(self)) }
 end
 
+-- WHAT THE CLIENT HEALED, MEASURED PER FRAME. While the peer's avatar rules our bars
+-- (player.lua MP_SelfStats writes them ~4 Hz), a potion, resting or a self-cast restore
+-- raises the LOCAL bar between two reports and the next report puts it straight back --
+-- so the 4 Hz diff below rarely saw the raise at all, and the server never heard of it
+-- (measured: sethp to full, peer-reported bars stayed down; a potion healed a fraction).
+-- The heal is still real: it is the sum of the per-frame increases, which no report can
+-- take away. Accumulated here, claimed on top of the peer's last word at the next diff.
+local peerHp = nil -- the last hp the peer reported for us (nil: nobody is reporting)
+local prevHp = nil -- last frame's local hp, after any report was applied
+local hpGain = 0   -- local increases since the last claim
+function identity.notePeerBars(hp)
+    peerHp = hp
+    prevHp = hp -- a report's own write is not a local gain (nor a loss)
+end
+local function trackLocalGain()
+    local ok, h = pcall(function() return Actor.stats.dynamic.health(self).current end)
+    if not ok or not h then return end
+    if prevHp and h > prevHp then hpGain = hpGain + (h - prevHp) end
+    prevHp = h
+end
+
 local function snapProgression()
     local attributes, skills = {}, {}
     for _, id in ipairs(ATTRIBUTES) do
@@ -300,10 +321,17 @@ function identity.tick(now)
     end
     wasDead = dead
 
+    trackLocalGain()
     if now >= nextAt.dynamic then
         nextAt.dynamic = now + INTERVALS.dynamic
         local dyn = snapDynamic()
         mp.set('hp', tostring(dyn.hp.c)) -- mirror unconditionally (diff may be seeded)
+        if peerHp and hpGain > 0.5 and not dead then
+            -- Claim the heal on top of what the peer last said, not on top of whatever the
+            -- local bar shows this frame (which a report may have just reset).
+            dyn.hp.c = math.floor(math.min(dyn.hp.b, peerHp + hpGain) + 0.5)
+        end
+        hpGain = 0
         local fp = fingerprint(dyn)
         if fp ~= last.dynamic then
             last.dynamic = fp
@@ -411,6 +439,7 @@ end
 
 function identity.reset()
     last = {}
+    peerHp, prevHp, hpGain = nil, nil, 0
     -- nil, NOT {}: the next pass must re-seed the baseline rather than treat the whole restored
     -- inventory as newly acquired.
     acqCounts = nil

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -153,12 +153,12 @@ end
 -- take away. Accumulated here, claimed on top of the peer's last word at the next diff.
 -- Magicka is the same story in BOTH directions: the avatar never casts, so a cast's cost is
 -- a local drop the next report refills (casting was free half the time), and a restore
--- potion is a local rise it takes away. Health and fatigue claim gains only (damage is the
--- peer's); magicka claims the net local change.
+-- potion is a local rise it takes away. Health claims gains only (damage is the peer's);
+-- magicka claims the net local change. Fatigue is NOT tracked: both engines regenerate it,
+-- so claiming our regen on top of the avatar's would double the recovery rate.
 local tracked = {
     hp = { stat = 'health', gainsOnly = true },
     mp = { stat = 'magicka', gainsOnly = false },
-    ft = { stat = 'fatigue', gainsOnly = true },
 }
 for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
 function identity.notePeerBars(hp, mpv, ft)

--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -151,18 +151,34 @@ end
 -- (measured: sethp to full, peer-reported bars stayed down; a potion healed a fraction).
 -- The heal is still real: it is the sum of the per-frame increases, which no report can
 -- take away. Accumulated here, claimed on top of the peer's last word at the next diff.
-local peerHp = nil -- the last hp the peer reported for us (nil: nobody is reporting)
-local prevHp = nil -- last frame's local hp, after any report was applied
-local hpGain = 0   -- local increases since the last claim
-function identity.notePeerBars(hp)
-    peerHp = hp
-    prevHp = hp -- a report's own write is not a local gain (nor a loss)
+-- Magicka is the same story in BOTH directions: the avatar never casts, so a cast's cost is
+-- a local drop the next report refills (casting was free half the time), and a restore
+-- potion is a local rise it takes away. Health and fatigue claim gains only (damage is the
+-- peer's); magicka claims the net local change.
+local tracked = {
+    hp = { stat = 'health', gainsOnly = true },
+    mp = { stat = 'magicka', gainsOnly = false },
+    ft = { stat = 'fatigue', gainsOnly = true },
+}
+for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
+function identity.notePeerBars(hp, mpv, ft)
+    local v = { hp = hp, mp = mpv, ft = ft }
+    for k, t in pairs(tracked) do
+        if v[k] ~= nil then
+            t.peer = v[k]
+            t.prev = v[k] -- a report's own write is neither a local gain nor a loss
+        end
+    end
 end
-local function trackLocalGain()
-    local ok, h = pcall(function() return Actor.stats.dynamic.health(self).current end)
-    if not ok or not h then return end
-    if prevHp and h > prevHp then hpGain = hpGain + (h - prevHp) end
-    prevHp = h
+local function trackLocalChange()
+    for _, t in pairs(tracked) do
+        local ok, cur = pcall(function() return Actor.stats.dynamic[t.stat](self).current end)
+        if ok and cur and t.prev then
+            local d = cur - t.prev
+            if d > 0 or not t.gainsOnly then t.delta = t.delta + d end
+        end
+        if ok and cur then t.prev = cur end
+    end
 end
 
 local function snapProgression()
@@ -321,17 +337,19 @@ function identity.tick(now)
     end
     wasDead = dead
 
-    trackLocalGain()
+    trackLocalChange()
     if now >= nextAt.dynamic then
         nextAt.dynamic = now + INTERVALS.dynamic
         local dyn = snapDynamic()
         mp.set('hp', tostring(dyn.hp.c)) -- mirror unconditionally (diff may be seeded)
-        if peerHp and hpGain > 0.5 and not dead then
-            -- Claim the heal on top of what the peer last said, not on top of whatever the
-            -- local bar shows this frame (which a report may have just reset).
-            dyn.hp.c = math.floor(math.min(dyn.hp.b, peerHp + hpGain) + 0.5)
+        for k, t in pairs(tracked) do
+            if t.peer and math.abs(t.delta) > 0.5 and not dead then
+                -- Claim the local change on top of what the peer last said, not on top of
+                -- whatever the bar shows this frame (which a report may have just reset).
+                dyn[k].c = math.floor(math.max(0, math.min(dyn[k].b, t.peer + t.delta)) + 0.5)
+            end
+            t.delta = 0
         end
-        hpGain = 0
         local fp = fingerprint(dyn)
         if fp ~= last.dynamic then
             last.dynamic = fp
@@ -439,7 +457,7 @@ end
 
 function identity.reset()
     last = {}
-    peerHp, prevHp, hpGain = nil, nil, 0
+    for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
     -- nil, NOT {}: the next pass must re-seed the baseline rather than treat the whole restored
     -- inventory as newly acquired.
     acqCounts = nil

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -833,7 +833,7 @@ return {
             -- Scenario mirror: proves the PEER-authoritative bars actually flowed (a local
             -- fall would drop hp too; only this marker distinguishes the sources).
             mp.set('selfStats', string.format('%.0f/%.0f', data.hp.c, data.hp.b))
-            identity.notePeerBars(data.hp.c)
+            identity.notePeerBars(data.hp.c, data.mp and data.mp.c, data.ft and data.ft.c)
             pcall(function()
                 local d = types.Actor.stats.dynamic
                 d.health(self).current = data.hp.c

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -833,6 +833,7 @@ return {
             -- Scenario mirror: proves the PEER-authoritative bars actually flowed (a local
             -- fall would drop hp too; only this marker distinguishes the sources).
             mp.set('selfStats', string.format('%.0f/%.0f', data.hp.c, data.hp.b))
+            identity.notePeerBars(data.hp.c)
             pcall(function()
                 local d = types.Actor.stats.dynamic
                 d.health(self).current = data.hp.c

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -584,6 +584,12 @@ local function dispatch(cmd)
         if hp then
             types.Actor.stats.dynamic.health(self).current = tonumber(hp)
         end
+        -- setmp:<n>: what a cast (lower) or a restore-magicka potion (higher) does to the
+        -- local bar; the avatar never casts, so this is the only writer of magicka (s113).
+        local mpv = cmd:match('^setmp:(-?[%d.]+)$')
+        if mpv then
+            types.Actor.stats.dynamic.magicka(self).current = tonumber(mpv)
+        end
         local race, head, hair = cmd:match('^applyrace:([^:]+):([^:]+):([^:]*)$')
         if race then
             mp.applyChargen({ race = race, head = head, hair = hair, isMale = true })
@@ -833,6 +839,7 @@ return {
             -- Scenario mirror: proves the PEER-authoritative bars actually flowed (a local
             -- fall would drop hp too; only this marker distinguishes the sources).
             mp.set('selfStats', string.format('%.0f/%.0f', data.hp.c, data.hp.b))
+            if data.mp then mp.set('selfMagicka', string.format('%.0f/%.0f', data.mp.c, data.mp.b)) end
             identity.notePeerBars(data.hp.c, data.mp and data.mp.c, data.ft and data.ft.c)
             pcall(function()
                 local d = types.Actor.stats.dynamic

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -22,7 +22,8 @@ s59 (spell forward), s78 (crime pursuit), s79 (pickup race), s51 (NPC combat), s
 creatures named once, built on both clients), s108 (trade both ways, one inventory at every
 step), s109 (two players kill a peer-named wild creature -- FAILED first: every client rolled
 a private ghost of each creature near the spawn before the spawn gate was down; fixed the
-same day, engine default + Lua), s95 (play with friends -- FAILED first: every
+same day, engine default + Lua), s110 (a provoked wild creature's blows reach the player: peer
+avatar damage -> SelfStats, no hit injection on the victim), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -23,7 +23,11 @@ creatures named once, built on both clients), s108 (trade both ways, one invento
 step), s109 (two players kill a peer-named wild creature -- FAILED first: every client rolled
 a private ghost of each creature near the spawn before the spawn gate was down; fixed the
 same day, engine default + Lua), s110 (a provoked wild creature's blows reach the player: peer
-avatar damage -> SelfStats, no hit injection on the victim), s95 (play with friends -- FAILED first: every
+avatar damage -> SelfStats, no hit injection on the victim), s111 (two players loot the same kill:
+canonical corpse, one take wins, by net id), s112 (a client heal sticks against the peer's bars --
+FAILED twice first: the heal was reset before it was reported, then the avatar's stat write
+threw in a pcall), s113 (a cast costs magicka and a potion restores it -- FAILED first: an echoed
+report refilled the bar), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
@@ -86,8 +90,8 @@ scenario is a code trace only.
 
 | Action | MP path | Status |
 |---|---|---|
-| hp/mp/ft | peer-authored while driving; client may raise (heal); magicka client both ways | FIXED 09-11 (free casting) |
-| Attributes/skills/level, training, level-up | client diff -> doc -> AvatarState | OK |
+| hp/mp/ft | peer-authored while driving; client may raise (heal); magicka client both ways. identity.lua measures the LOCAL change per frame and claims only the changed bars on top of the peer's last report (an echoed snapshot used to undo bites and refill casts; a heal was reset before the 4 Hz diff saw it) | FIXED 09-11 twice. Live: s112 (heal sticks), s113 (cast costs, potion restores) |
+| Attributes/skills/level, training, level-up | client diff -> doc -> AvatarState -> avatar.lua mpAvatarStats (Self context: every stat setter is Self-gated, the global-script write threw inside a pcall and the avatar stayed a level-1 template with a template health pool) | FIXED 09-11 |
 | Skill use from cancelled swings | skill use runs before the Lua cancel | OK |
 | Diseases (caught) | AvatarEffectsBatch -> doc.spells + owner | FIXED 09-11 |
 | Vampirism / lycanthropy | spell list / appearance; werewolf form set on rebuilt bodies | FIXED 09-11 (looked human) |

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -28,8 +28,8 @@ join refused not_open, fixed the same day), s100 (invite across worlds), s102 (o
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
 s30 (objects), s50 (combat), s52 (pvp off), s60/s60b (journal), s62 (quest vars), s71
-(records), s73/s75 (topics), s69 (peer outage). SKIP by design: s66 (covered by server
-tests), s63 (rewrite pending), s40/s42 (host-load guard). Anything below marked OK without a
+(records), s73/s75 (topics), s69 (peer outage). s66 (PvP damage lands on the driving victim's avatar and the peer's bars reach the owner --
+re-armed 09-11, PASS). SKIP by design: s63 (rewrite pending), s40/s42 (host-load guard). Anything below marked OK without a
 scenario is a code trace only.
 
 ## 1. Session

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -129,12 +129,17 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
   const hp = parseDynamicStat(body.get('hp'));
   const mp = parseDynamicStat(body.get('mp'));
   const ft = parseDynamicStat(body.get('ft'));
-  if (!hp || !mp || !ft) return false;
+  if (!hp && !mp && !ft) return false;
   // Phase 4A: while the PEER is reporting this player's avatar bars, the client's own
   // assertion is ignored -- one writer, same shape as the movement freshness gate. The
   // client's claim resumes ruling the moment peer reports stop (peer down, input tier
   // inactive for this player), so degraded mode needs no switchover signal here either.
   if (player.peerStatsAt !== undefined && Date.now() - player.peerStatsAt <= PEER_STATS_FRESH_MS) {
+    // A CLAIM NAMES ONLY WHAT THE CLIENT CHANGED. identity.lua sends just the bars it has a
+    // local heal or spend for while the peer rules; a bar it merely echoes from the peer's
+    // last report is omitted. Echoed, a report already overtaken by damage on the peer
+    // re-raised the health (the bite undone) and re-filled the magicka (the cast free)
+    // -- s113 measured the spend land at 12/50 and bounce back to 50/50 three seconds later.
     // CLIENT MAY HEAL, PEER MAY HURT. Potions, resting and self-cast healing all happen on
     // the client's engine (the avatar drinks nothing until the intent tier lands), so a
     // client assertion that RAISES a bar is a restoration and must reach the avatar -- or
@@ -161,7 +166,7 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
       const want = Math.max(0, Math.min(v.c, have.b));
       return Math.abs(want - have.c) > 0.5 ? { c: want, b: have.b } : undefined;
     };
-    const r = { hp: raise('hp', hp), mp: spend(mp), ft: raise('ft', ft) };
+    const r = { hp: hp && raise('hp', hp), mp: mp && spend(mp), ft: ft && raise('ft', ft) };
     if (!r.hp && !r.mp && !r.ft) return true; // nothing restored: consumed, not applied
     // Budget the HEALTH restoration (the one that decides whether you die).
     const gained = r.hp ? r.hp.c - (cur?.hp?.c ?? r.hp.c) : 0;
@@ -192,6 +197,8 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
   // and closes the tab in the same second would otherwise rejoin alive — a progress bug and
   // an exploit at once. Being alive is still cheap (sweep), so this costs a write per death,
   // not per tick.
+  // Client-authoritative (nobody simulating this player): the full triple is the contract.
+  if (!hp || !mp || !ft) return false;
   const died = hp.c <= 0;
   ctx.store.update(player.charId, (doc) => {
     doc.stats = { ...doc.stats, dynamic: { hp, mp, ft } };

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -139,6 +139,16 @@ env.dyn.health.current = 40
 identity.tick(0.60)
 got = dynEvents(env.calls)
 check('a peer-authored drop is not re-claimed as a heal', got[#got].hp.c == 40, 'hp=' .. tostring(got[#got].hp.c))
+identity.notePeerBars(nil, 50, nil) -- the peer says magicka 50/50
+env.dyn.magicka.current = 50
+identity.tick(0.90)
+env.dyn.magicka.current = 30       -- frame: we cast (-20)
+identity.tick(0.95)
+identity.notePeerBars(nil, 50, nil) -- the avatar never cast: its report refills the bar
+env.dyn.magicka.current = 50
+identity.tick(1.20)
+got = dynEvents(env.calls)
+check('the cost of a cast survives the refill from the avatar', got[#got].mp.c == 30, 'mp=' .. tostring(got[#got].mp.c))
 
 -- ==================================================== social.lua: refusal text for the player
 -- SocialResult carries a WIRE CODE. It was rendered straight into the UI, so a refused op

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -138,7 +138,7 @@ identity.notePeerBars(40)      -- the peer hurts us: a report LOWER than local
 env.dyn.health.current = 40
 identity.tick(0.60)
 got = dynEvents(env.calls)
-check('a peer-authored drop is not re-claimed as a heal', got[#got].hp.c == 40, 'hp=' .. tostring(got[#got].hp.c))
+check('a peer-authored drop is neither re-claimed nor echoed', #got == n0 + 1, 'events=' .. #got)
 identity.notePeerBars(nil, 50, nil) -- the peer says magicka 50/50
 env.dyn.magicka.current = 50
 identity.tick(0.90)

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -104,6 +104,42 @@ identity.tick(3.0)
 check('reset re-seeds rather than reporting the restored inventory',
   #acquiredEvents(env.calls) == 1, '#got=' .. #acquiredEvents(env.calls))
 
+-- ------------------------------------------------------------ identity.lua: a heal sticks
+-- While the peer reports our bars, a potion raises the local bar between two reports and the
+-- next report puts it back; the 4 Hz diff seldom saw it. The per-frame gain is claimed on
+-- top of the peer's last word instead.
+print('identity.lua — client heal claimed over the peer report')
+local function dynEvents(calls)
+  local out = {}
+  for _, c in ipairs(calls.events) do
+    if c.name == 'PlayerStatsDynamic' then out[#out + 1] = c.body end
+  end
+  return out
+end
+fresh()
+env = stubs.install({})
+identity = require('scripts.mp.identity')
+identity.markBaselineReady()
+env.dyn.health.current = 60
+identity.notePeerBars(60)      -- the peer says 60/100
+identity.tick(0)               -- seeds: 60
+local n0 = #dynEvents(env.calls)
+env.dyn.health.current = 75    -- frame: the potion ticked (+15)
+identity.tick(0.05)
+identity.notePeerBars(60)      -- the peer's next report resets the bar...
+env.dyn.health.current = 60
+identity.tick(0.10)
+env.dyn.health.current = 62    -- ...and the potion keeps ticking (+2)
+identity.tick(0.30)            -- past the 0.25 s diff
+local got = dynEvents(env.calls)
+check('the heal is claimed as peer + local gain, not the reset bar',
+  #got == n0 + 1 and got[#got].hp.c == 77, 'events=' .. #got .. ' hp=' .. tostring(got[#got] and got[#got].hp.c))
+identity.notePeerBars(40)      -- the peer hurts us: a report LOWER than local
+env.dyn.health.current = 40
+identity.tick(0.60)
+got = dynEvents(env.calls)
+check('a peer-authored drop is not re-claimed as a heal', got[#got].hp.c == 40, 'hp=' .. tostring(got[#got].hp.c))
+
 -- ==================================================== social.lua: refusal text for the player
 -- SocialResult carries a WIRE CODE. It was rendered straight into the UI, so a refused op
 -- said things like "InviteSend: blocked" and a successful one said "InviteSend: ok".

--- a/wasm-build/lua-tests/stubs.lua
+++ b/wasm-build/lua-tests/stubs.lua
@@ -154,6 +154,7 @@ function M.install(opts)
     advance = function(sec) realTime = realTime + sec end,
     now = function() return realTime end,
     setInventory = function(items) inventory = items end,
+    dyn = dyn, -- the dynamic stats, mutable: a heal is `dyn.health.current = 100`
     spellbook = spellbook,
     world = world,
     globals = globalVars,

--- a/wasm-build/mp-scenarios/s110-wild-bites-back.mjs
+++ b/wasm-build/mp-scenarios/s110-wild-bites-back.mjs
@@ -1,0 +1,57 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s110: THE CREATURE BITES BACK. s109 proves two players can kill a wild creature; this is
+// the other half of every fight in the game: the creature's blows land on the PLAYER. Nothing
+// on the player's own screen can do that -- the creature there is a puppet with its AI off.
+// The peer's creature attacks the player's avatar, the avatar's bars ride AvatarStatsBatch
+// back to the server, and the owner receives SelfStats (player.lua mirrors it as selfStats).
+// If that chain is broken a player is invulnerable to the whole wilderness, which is exactly
+// as game-breaking as the s109 ghost was, in the other direction.
+//
+// s66 covers the same bars for PvP at the unit tier only; this is the product path, live: no
+// hit injection on the victim at all, just a provoked creature and an avatar standing in
+// reach of it.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const SPOT = '-12500,-53100,512'; // inside -2,-7 (see s109)
+
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const netObjs = async (c) => JSON.parse(await c.eval('window.omw.state.netObjects||"{}"'));
+const parseBars = (s) => { const m = /^(\d+)\/(\d+)$/.exec(String(s ?? '')); return m ? { c: Number(m[1]), b: Number(m[2]) } : null; };
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-7');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const a = await ctx.launchClient('bot-a', '', BOOT);
+  await a.cmd('snapto:' + SPOT);
+  await a.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'A built a named creature');
+  await a.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 30_000, 'A puppeted the cell actors');
+
+  // Stand next to the creature: a bite has a reach, and the avatar follow-teleports with us.
+  const names = Object.values(await netObjs(a));
+  const probe = await probeOf(a);
+  const victim = names.find((r) => probe[r] && !probe[r].dead);
+  assert.ok(victim, `no living named creature in the probe: net=${JSON.stringify(names)} probe=${JSON.stringify(Object.keys(probe))}`);
+  const p = probe[victim];
+  await a.cmd(`snapto:${Math.round(p.x + 60)},${Math.round(p.y)},${Math.round(p.z + 8)}`);
+  await ctx.sleep(3_000);
+  ctx.log(`A stands beside the peer's "${victim}" at (${Math.round(p.x)},${Math.round(p.y)},${Math.round(p.z)})`);
+
+  // Provoke it once (a scrib will not start a fight on its own) and wait for the bars the
+  // PEER reports to drop below full. selfStats only ever moves on the peer path.
+  const before = parseBars(await a.eval('window.omw.state.selfStats'));
+  ctx.log(`selfStats before=${before ? before.c + '/' + before.b : 'none'}`);
+  const deadline = Date.now() + 120_000;
+  let bars = null, dropped = false, pokes = 0;
+  while (Date.now() < deadline && !dropped) {
+    if (pokes < 3) { await a.cmd(`hitn:${victim}:1`); pokes++; }
+    await ctx.sleep(2_000);
+    bars = parseBars(await a.eval('window.omw.state.selfStats'));
+    dropped = !!bars && bars.c < bars.b;
+  }
+  ctx.log(`selfStats after=${bars ? bars.c + '/' + bars.b : 'none'} hitFwd=${await a.eval('window.omw.state.hitFwd')} probe=${JSON.stringify((await probeOf(a))[victim])}`);
+  assert.ok(dropped, `the player's peer-reported health never dropped while standing in reach of a provoked "${victim}": `
+    + 'either the peer creature does not attack avatars, or its damage never reached the owner as SelfStats');
+  ctx.log(`ok: the peer's ${victim} hurt the player and the owner's bars followed (${bars.c}/${bars.b})`);
+}

--- a/wasm-build/mp-scenarios/s111-loot-the-kill.mjs
+++ b/wasm-build/mp-scenarios/s111-loot-the-kill.mjs
@@ -1,0 +1,78 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s111: LOOT THE KILL. After the fight (s109) comes the corpse. Every client holds its own
+// copy of a peer-named creature's inventory (each engine rolled it from the record), so the
+// corpse is a shared container exactly like a chest: the first opener's snapshot becomes
+// canonical, every later opener receives it, and a take is a server transaction that ONE
+// player wins. Without that, two players looting the same kill each walk away with the loot.
+//
+// The creature is addressed by NET ID at every hop (it has no content ref), which is the new
+// thing here over s31's chest.
+import assert from 'node:assert/strict';
+
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const SPOT = '-12500,-53100,512';
+
+const netObjs = async (c) => JSON.parse(await c.eval('window.omw.state.netObjects||"{}"'));
+const corpseHas = (netId, itemId, n) =>
+  `(JSON.parse(window.omw.state.containerItems||"{}")["n:${netId}"]||{})[${JSON.stringify(itemId)}] === ${n}`
+  + (n === 0 ? ` || !((JSON.parse(window.omw.state.containerItems||"{}")["n:${netId}"]||{})[${JSON.stringify(itemId)}])` : '');
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-7');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  await a.cmd('snapto:' + SPOT);
+  await b.cmd('snapto:' + SPOT);
+  await a.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'A built a named creature');
+  await b.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'B built a named creature');
+  const oa = await netObjs(a), ob = await netObjs(b);
+  const netId = Object.keys(oa).find((id) => ob[id] === oa[id]);
+  assert.ok(netId, 'no creature both clients agree on');
+  const victim = oa[netId];
+  for (const c of [a, b]) await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', STEP, `${c.name} puppeted the cell actors`);
+
+  // Kill it (the s109 chain).
+  const deadExpr = `((JSON.parse(window.omw.state.actorProbe||"{}")[${JSON.stringify(victim)}]||{}).dead === true)`;
+  const deadline = Date.now() + 90_000;
+  let died = false;
+  while (Date.now() < deadline && !died) {
+    await a.cmd(`hitn:${victim}:40`);
+    await ctx.sleep(600);
+    died = (await a.eval(deadExpr)) === true;
+  }
+  assert.ok(died, `the ${victim} never died (s109 covers this)`);
+  await b.waitFor(deadExpr, STEP, 'B sees it dead');
+  ctx.log(`the peer's "${victim}" (net ${netId}) is dead on both screens; looting`);
+
+  // A opens the corpse and puts one item in it, so there is something definite to race for
+  // (a creature's own roll may be empty). The put is the same watch-diff path the UI takes.
+  await a.cmd('equiptest');
+  await a.waitFor('(window.omw.state.equippedIds||"") !== ""', 12_000, 'A holds the test item');
+  const itemId = (await a.eval('window.omw.state.equippedIds')).split(',')[0];
+  await a.cmd(`chest:open:${netId}`);
+  await a.waitFor(`Object.prototype.hasOwnProperty.call(JSON.parse(window.omw.state.containerItems||"{}"), "n:${netId}")`,
+    STEP, 'the corpse registered as a shared container on A (ContainerOpen by net id)');
+  await a.cmd(`chest:put:${itemId}`);
+  await a.waitFor(corpseHas(netId, itemId, 1), STEP, 'the corpse holds the item on A');
+
+  // B opens: receives the canonical contents, including A's item.
+  await b.cmd(`chest:open:${netId}`);
+  await b.waitFor(corpseHas(netId, itemId, 1), STEP, 'the corpse state synced to B');
+  ctx.log('ok: canonical corpse contents on both clients');
+
+  // Both grab it: one winner, corpse empty everywhere.
+  await Promise.all([a.cmd(`chesttake:${netId}:${itemId}`), b.cmd(`chesttake:${netId}:${itemId}`)]);
+  await a.waitFor('!!window.omw.state.chestOp', STEP, 'A got an op result');
+  await b.waitFor('!!window.omw.state.chestOp', STEP, 'B got an op result');
+  const opA = JSON.parse(await a.eval('window.omw.state.chestOp'));
+  const opB = JSON.parse(await b.eval('window.omw.state.chestOp'));
+  ctx.log(`race: A ok=${opA.ok} (${opA.reason ?? ''}), B ok=${opB.ok} (${opB.reason ?? ''})`);
+  assert.equal([opA, opB].filter((o) => o.ok).length, 1, 'exactly ONE take must win');
+  await a.waitFor(corpseHas(netId, itemId, 0), STEP, 'corpse empty on A');
+  await b.waitFor(corpseHas(netId, itemId, 0), STEP, 'corpse empty on B');
+  const errs = a.luaErrors().concat(b.luaErrors());
+  assert.equal(errs.length, 0, 'Lua errors while looting:\n' + errs.join('\n'));
+  ctx.log('ok: the kill was looted once, by one player');
+}

--- a/wasm-build/mp-scenarios/s112-heal-sticks.mjs
+++ b/wasm-build/mp-scenarios/s112-heal-sticks.mjs
@@ -1,0 +1,68 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s112: A HEAL STICKS. The peer's bars rule a driving player (s110 proved the creature's
+// damage lands), so anything the player does to their OWN bars -- a potion, resting, a
+// self-cast Restore Health -- is a client claim the server must forward to the avatar as a
+// restore. If it does not, the avatar's next report knocks the bar straight back down and
+// every potion in the game does nothing (measured once, 2026-09: "overwritten by the
+// un-restored avatar three seconds later"). Unit-tier: avatarstats.test.ts. This is it live:
+// get bitten, heal to full on the client, and the PEER-reported bars must follow up.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const SPOT = '-12500,-53100,512';
+
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const netObjs = async (c) => JSON.parse(await c.eval('window.omw.state.netObjects||"{}"'));
+const parseBars = (s) => { const m = /^(\d+)\/(\d+)$/.exec(String(s ?? '')); return m ? { c: Number(m[1]), b: Number(m[2]) } : null; };
+const bars = async (c) => parseBars(await c.eval('window.omw.state.selfStats'));
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-7');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const a = await ctx.launchClient('bot-a', '', BOOT);
+  await a.cmd('snapto:' + SPOT);
+  await a.waitFor('Object.keys(JSON.parse(window.omw.state.netObjects||"{}")).length > 0', 120_000, 'A built a named creature');
+  await a.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 30_000, 'A puppeted the cell actors');
+  const names = Object.values(await netObjs(a));
+  const probe = await probeOf(a);
+  const victim = names.find((r) => probe[r] && !probe[r].dead);
+  assert.ok(victim, 'no living named creature');
+  const p = probe[victim];
+  await a.cmd(`snapto:${Math.round(p.x + 60)},${Math.round(p.y)},${Math.round(p.z + 8)}`);
+  await ctx.sleep(3_000);
+
+  // Get hurt (s110's chain), then walk away so the bite stops.
+  let hurt = null, pokes = 0;
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline && !(hurt && hurt.c < hurt.b)) {
+    if (pokes < 3) { await a.cmd(`hitn:${victim}:1`); pokes++; }
+    await ctx.sleep(2_000);
+    hurt = await bars(a);
+  }
+  assert.ok(hurt && hurt.c < hurt.b, `never got hurt (selfStats=${JSON.stringify(hurt)}); s110 covers this`);
+  await a.cmd(`snapto:${Math.round(p.x + 2500)},${Math.round(p.y)},${Math.round(p.z + 8)}`);
+  await ctx.sleep(4_000);
+  const before = await bars(a);
+  ctx.log(`hurt: selfStats=${before.c}/${before.b} (out of the creature's reach now)`);
+  assert.ok(before.c < before.b, 'should still be hurt after stepping away');
+
+  // The potion: a client-side heal to full. Nothing on the peer did this.
+  await a.cmd(`sethp:${before.b}`);
+  const healDeadline = Date.now() + 20_000;
+  let after = null;
+  while (Date.now() < healDeadline) {
+    after = await bars(a);
+    if (after && after.c >= after.b) break;
+    await ctx.sleep(500);
+  }
+  ctx.log(`after the heal: selfStats=${after ? after.c + '/' + after.b : 'none'}`);
+  assert.ok(after && after.c >= after.b,
+    'the client heal never reached the avatar: the peer-reported bars stayed down, so the '
+    + 'next report will undo the potion (the "every potion does nothing" failure)');
+  // And it STAYS: two more reports later the avatar still agrees.
+  await ctx.sleep(3_000);
+  const later = await bars(a);
+  assert.ok(later && later.c >= later.b, `the heal was undone: selfStats=${later.c}/${later.b}`);
+  ctx.log(`ok: a client heal became the avatar's truth and stayed (${later.c}/${later.b})`);
+}

--- a/wasm-build/mp-scenarios/s113-cast-costs.mjs
+++ b/wasm-build/mp-scenarios/s113-cast-costs.mjs
@@ -16,7 +16,7 @@ export default async function run(ctx) {
   const simPeer = ctx.startSimPeer('-2,-9');
   if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
   const a = await ctx.launchClient('bot-a', '', BOOT);
-  await a.waitFor('/^\d+\/\d+$/.test(String(window.omw.state.selfMagicka||""))', 300_000, 'the peer reports A\'s magicka (driving the input tier)');
+  await a.waitFor('String(window.omw.state.selfMagicka||"").indexOf("/") > 0', 300_000, 'the peer reports the magicka of A (driving the input tier)');
   const full = parseBars(await a.eval('window.omw.state.selfMagicka'));
   ctx.log(`peer-reported magicka: ${full.c}/${full.b}`);
   assert.ok(full.b >= 2, 'need a magicka pool to spend from');

--- a/wasm-build/mp-scenarios/s113-cast-costs.mjs
+++ b/wasm-build/mp-scenarios/s113-cast-costs.mjs
@@ -1,0 +1,52 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s113: A CAST COSTS MAGICKA. The avatar on the peer never casts (the owner's client casts
+// and forwards the hit), so the only thing that ever lowers magicka is the owner's own
+// engine -- and the peer's bar report, which rules a driving player, says "full" four times
+// a second. Unless the client's spend reaches the avatar, every spell is free and the bar
+// flickers. Unit tier: avatarstats.test.ts ("MAGICKA GOES DOWN TOO"). Live: spend on the
+// client, and the PEER-reported magicka must come down and stay down; then a restore
+// (potion) must bring it back up the same way.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const parseBars = (s) => { const m = /^(\d+)\/(\d+)$/.exec(String(s ?? '')); return m ? { c: Number(m[1]), b: Number(m[2]) } : null; };
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const a = await ctx.launchClient('bot-a', '', BOOT);
+  await a.waitFor('/^\d+\/\d+$/.test(String(window.omw.state.selfMagicka||""))', 300_000, 'the peer reports A\'s magicka (driving the input tier)');
+  const full = parseBars(await a.eval('window.omw.state.selfMagicka'));
+  ctx.log(`peer-reported magicka: ${full.c}/${full.b}`);
+  assert.ok(full.b >= 2, 'need a magicka pool to spend from');
+
+  const settle = async (pred, what) => {
+    const deadline = Date.now() + 20_000;
+    let v = null;
+    while (Date.now() < deadline) {
+      v = parseBars(await a.eval('window.omw.state.selfMagicka'));
+      if (v && pred(v)) break;
+      await ctx.sleep(400);
+    }
+    return v;
+  };
+
+  // The cast: local magicka drops to a quarter. The avatar's report says full until the
+  // spend reaches it.
+  const spent = Math.floor(full.b / 4);
+  await a.cmd(`setmp:${spent}`);
+  let v = await settle((b) => b.c <= spent + 1, 'spend');
+  ctx.log(`after the cast: peer-reported ${v ? v.c + '/' + v.b : 'none'}`);
+  assert.ok(v && v.c <= spent + 1, 'the spend never reached the avatar: the peer still reports the bar full, so the cast was free');
+  await ctx.sleep(3_000);
+  v = parseBars(await a.eval('window.omw.state.selfMagicka'));
+  assert.ok(v.c <= spent + 1, `the spend was undone by a later report: ${v.c}/${v.b}`);
+
+  // The potion: back to full on the client; the avatar must follow.
+  await a.cmd(`setmp:${full.b}`);
+  v = await settle((b) => b.c >= b.b, 'restore');
+  ctx.log(`after the potion: peer-reported ${v ? v.c + '/' + v.b : 'none'}`);
+  assert.ok(v && v.c >= v.b, 'the restore never reached the avatar');
+  ctx.log('ok: a cast costs magicka and a potion restores it, on the bars the peer reports');
+}

--- a/wasm-build/mp-scenarios/s66-avatar-bars.mjs
+++ b/wasm-build/mp-scenarios/s66-avatar-bars.mjs
@@ -33,23 +33,9 @@ const STEP_TIMEOUT = 30_000;
 const BOOT = { retail: true, joinTimeoutMs: 420_000 };
 
 export default async function run(ctx) {
-  // ponytail: SKIPPED at the browser tier, PROVEN at the unit tier.
-  //
-  // 4A (peer reports avatar bars -> owner MP_SelfStats) and 4B (a driving victim's PvP hit
-  // routes to the peer) are both covered rigorously by server/test/avatarstats.test.ts and
-  // the PvP-routing case in server/test/inputauthority.test.ts. This scenario would drive the
-  // same server code through two real browsers, but it is blocked on a HARNESS mechanic, not
-  // product code: injecting a player-vs-player hit needs `hitp` to raise an engine `Hit` on
-  // the attacker's local puppet of the victim so puppet.lua's interceptor forwards a
-  // CombatHit -- and that injection produces no CombatHit here even with the attacker
-  // confirmed puppeting the victim and pvp on, while the identical path for an NPC target
-  // (s51, s58) works. Real-play melee raises that `Hit` for free; the harness's synthetic one
-  // does not. Verified along the way that the server DOES send MP_SelfStats (simpeer log) and
-  // that global.lua now forwards it to player.lua -- the real 4A bug this scenario surfaced.
-  ctx.log('SKIP: 4A/4B covered by avatarstats.test.ts + inputauthority.test.ts; browser tier '
-    + 'blocked on player-target hit injection (hitp raises no CombatHit; NPC path s51/s58 works)');
-  return;
-
+  // Was SKIPPED at the browser tier (2026-09-05): hitp raised no CombatHit while the NPC path
+  // (s51/s58) worked. Re-armed 2026-09-11 with the test-hook diagnostics (mpTestHit prints the
+  // body it chose; puppet.lua prints test-hook interceptions) so a failure says where it stops.
   if (!existsSync(join(ROOT, 'play', 'mwdata', 'Morrowind.esm'))) {
     ctx.log('SKIP: play/mwdata/Morrowind.esm absent (retail data required)');
     return;


### PR DESCRIPTION
## What this pass found (all live, native peer + browser clients, retail data)
- **s110** the creature bites back: a provoked wild creature's blows reach the player's bars via the peer. PASS first run.
- **s111** loot the kill: two players loot the same peer-named corpse, canonical contents on both, one take wins, addressed by net id. PASS (chest hooks now address any lootable net body).
- **s112** a heal sticks. FAILED twice:
  1. the client's heal was reset by the peer's next report before the 4 Hz diff ever observed it (potions healed a fraction). identity.lua now measures the local change per frame and claims it on top of the peer's last word.
  2. the peer's `MP_AvatarRestore` wrote the avatar's health from the **global** script, which every stat setter refuses (Self-gated) — inside a pcall. The same pcall hid the same throw in `applyAvatarDoc`: **the avatar never received the owner's level, attributes, skills or health pool** — a level-20 player fought with a level-1 template body. Stats now land in `avatar.lua` (Self context); handoff snapshots land via `companion.lua`.
- **s113** a cast costs magicka and a potion restores it. FAILED first: the client echoed a peer report the peer had since overtaken, which the server took as a fresh claim (bite undone / cast refilled). While the peer rules, the client sends only the bars it changed; the server accepts a partial claim in that branch.
- **s66** re-armed at the browser tier (PvP damage → victim's bars): PASS.

## Gates
- Live: s109 s110 s112 s113 s22 s66 s21 s80 s77 s51 s59 s107 s111 s69 all PASS on the engine baked from this branch.
- tsc clean; server suite 1070 tests, 0 fail; Lua logic runner 113/113 (3 new checks). No engine C++ in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)