### PR TITLE
Gameplay pass: no NPC ever carried companion.lua (two lines, engine keeps the last); s114 companion follows on every screen

### DIFF
--- a/openmw/files/data/mp.omwscripts
+++ b/openmw/files/data/mp.omwscripts
@@ -12,8 +12,11 @@ MENU: scripts/mp/menu.lua
 # AI package state for a foreign actor -- an engine limitation, and the reason ActorAI sat as
 # dead protocol surface. An actor's own script can read its own packages. Silent unless the
 # answer changes, which for an ordinary NPC is never.
-NPC: scripts/mp/companion.lua
-CREATURE: scripts/mp/companion.lua
+# ONE LINE FOR BOTH TYPES. The engine keeps only the LAST line naming a script path
+# (components/lua/configuration.cpp: "only the last occurrence will be used"), so as two
+# lines this attached to creatures only -- no NPC ever had it, and no companion, escort or
+# scripted-travel claim was ever born on an NPC (s114 measured it).
+NPC,CREATURE: scripts/mp/companion.lua
 CUSTOM: scripts/mp/puppet.lua
 # Phase 3: the input-driven body on the SIM PEER only (global.lua attaches it when
 # mp.isSystem()); everywhere else the same body gets puppet.lua instead.

--- a/openmw/files/data/scripts/mp/actors.lua
+++ b/openmw/files/data/scripts/mp/actors.lua
@@ -538,7 +538,10 @@ function actors.noteFollow(obj, target, escort)
         -- (worldstate.ts followClaim) and relays it to the holder, who starts the package.
         local key = refKeyOf(obj)
         local own = deps.ownIdFn and deps.ownIdFn() or nil
-        if followId ~= nil and followId ~= own then return end
+        if followId ~= nil and followId ~= own then
+            pcall(function() mp.set('followClaim', 'not-mine:' .. tostring(followId) .. '/' .. tostring(own)) end)
+            return
+        end
         if followId == nil and not claimedFollow[key] then return end
         claimedFollow[key] = (followId ~= nil) or nil
         epoch = epoch or 0 -- a claim is not epoch-checked; the field only has to be present
@@ -547,6 +550,8 @@ function actors.noteFollow(obj, target, escort)
         cellKey = cellKey, epoch = epoch, follow = followId,
         escort = (followId ~= nil and type(escort) == 'table') and escort or nil,
     }, obj)
+    -- Scenario mirror (s114): what went out, or why nothing did.
+    pcall(function() mp.set('followClaim', body and ('sent:' .. tostring(followId)) or 'no-addr') end)
     if body then mp.sendEvent('ActorAI', body) end
 end
 
@@ -680,6 +685,10 @@ actors.handlers.MP_ActorAI = function(data)
         followersOf[data.follow][key] = { obj = obj, escort = data.escort }
     end
     local target = deps.playerObjOf and deps.playerObjOf(data.follow) or nil
+    if mp.isSystem and mp.isSystem() then
+        print(string.format('[mp] follow claim: %s -> player %s target=%s holder=%s', tostring(obj.recordId),
+            tostring(data.follow), target and 'yes' or 'NO', tostring(actors.isHolderOf(actors.cellKeyOfObj(obj)))))
+    end
     if target then
         aimAt(obj, target, data.escort)
     else

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -117,6 +117,21 @@ return {
         end,
     },
     eventHandlers = {
+        -- Scenario probe (s114): what this actor's AI stack looks like from its own script.
+        mpTestFollowProbe = function()
+            local out = {}
+            local okA, pkg = pcall(function() return I.AI.getActivePackage() end)
+            out[#out + 1] = 'active=' .. tostring(okA and pkg and pkg.type or (okA and 'none' or ('ERR:' .. tostring(pkg))))
+            local okT, targets = pcall(function() return I.AI.getTargets('Follow') end)
+            out[#out + 1] = 'followTargets=' .. tostring(okT and targets and #targets or ('ERR:' .. tostring(targets)))
+            if okT and targets and targets[1] then
+                local t = targets[1]
+                out[#out + 1] = 'first=' .. tostring(t.recordId) .. '/player=' .. tostring(types.Player.objectIsInstance(t))
+            end
+            local n = 0
+            pcall(function() I.AI.filterPackages(function(p) n = n + 1; out[#out + 1] = 'pkg:' .. tostring(p.type); return true end) end)
+            pcall(function() require('openmw.mp').set('followProbe', table.concat(out, ' ')) end)
+        end,
         -- THE BARS A HANDOFF HANDS US. Dynamic-stat setters are Self-gated (mwlua/stats.cpp),
         -- so the holder cannot write a snapshot's health onto an actor from the global script
         -- -- it threw inside a pcall, and every actor a new holder took over came back at

--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -108,6 +108,8 @@ return {
             local id = target and ((escort and 'escort:' or 'follow:') .. tostring(target.id)) or nil
             if id == reportedId then return end
             reportedId = id
+            -- Scenario mirror (s114): the last follow fact this actor reported.
+            pcall(function() require('openmw.mp').set('companionReport', tostring(self.object.recordId) .. '=' .. tostring(id)) end)
 
             -- The GLOBAL script decides whether we are the cell's authority and whether this
             -- is worth putting on the wire. This script only knows a fact about itself.

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2717,6 +2717,10 @@ local eventHandlers = {
     mpTestFollow = function(data)
         for _, obj in ipairs(world.activeActors) do
             if obj:isValid() and obj.recordId == data.id then
+                if data.probe then
+                    pcall(function() obj:sendEvent('mpTestFollowProbe', {}) end)
+                    return
+                end
                 -- The builtin ai.lua handles this on the NPC's own script, exactly like a
                 -- dialogue result's AIFollow lands.
                 local ok, err = pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = playerScript() }) end)

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2719,11 +2719,13 @@ local eventHandlers = {
             if obj:isValid() and obj.recordId == data.id then
                 -- The builtin ai.lua handles this on the NPC's own script, exactly like a
                 -- dialogue result's AIFollow lands.
-                pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = playerScript() }) end)
+                local ok, err = pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = playerScript() }) end)
+                pcall(function() mp.set('testFollow', ok and ('sent:' .. tostring(obj.id)) or ('failed:' .. tostring(err))) end)
                 return
             end
         end
         print('[mp] mpTestFollow: no actor with record ' .. tostring(data.id))
+        pcall(function() mp.set('testFollow', 'no-actor') end)
     end,
     -- Marks a topic as locally learned for the DIFF only; see quests.testLearnTopic for why
     -- the engine gives no way to do this for real from a script.

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2714,6 +2714,17 @@ local eventHandlers = {
     mpTestBounty = function(data) quests.testSetBounty(data.n) end,
     mpTestFaction = function(data) quests.testJoinFaction(data.id, data.rank) end,
     mpTestDialogue = function(data) quests.testActivateNpc(data.id) end,
+    mpTestFollow = function(data)
+        for _, obj in ipairs(world.activeActors) do
+            if obj:isValid() and obj.recordId == data.id then
+                -- The builtin ai.lua handles this on the NPC's own script, exactly like a
+                -- dialogue result's AIFollow lands.
+                pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = playerScript() }) end)
+                return
+            end
+        end
+        print('[mp] mpTestFollow: no actor with record ' .. tostring(data.id))
+    end,
     -- Marks a topic as locally learned for the DIFF only; see quests.testLearnTopic for why
     -- the engine gives no way to do this for real from a script.
     mpTestLearnTopic = function(data) quests.testLearnTopic(data.id) end,

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -697,6 +697,8 @@ local function dispatch(cmd)
         -- companion chain (companion.lua -> ActorAI claim -> holder) takes it from there (s114).
         local followRec = cmd:match('^follow:(.+)$')
         if followRec then core.sendGlobalEvent('mpTestFollow', { id = followRec }) end
+        local probeRec = cmd:match('^followprobe:(.+)$')
+        if probeRec then core.sendGlobalEvent('mpTestFollow', { id = probeRec, probe = true }) end
         if cmd == 'dlg:release' then
             core.sendGlobalEvent('mpDialogueClosed', {})
         else

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -692,6 +692,11 @@ local function dispatch(cmd)
             core.sendGlobalEvent('mpTestMemberVar',
                 { id = mvRec, name = mvName, value = tonumber(mvVal) })
         end
+        -- follow:<recordId>: what a recruiting dialogue result ("AIFollow player") does on the
+        -- recruiting player's own client -- stacks Follow on the local copy of the NPC. The
+        -- companion chain (companion.lua -> ActorAI claim -> holder) takes it from there (s114).
+        local followRec = cmd:match('^follow:(.+)$')
+        if followRec then core.sendGlobalEvent('mpTestFollow', { id = followRec }) end
         if cmd == 'dlg:release' then
             core.sendGlobalEvent('mpDialogueClosed', {})
         else

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -27,7 +27,8 @@ avatar damage -> SelfStats, no hit injection on the victim), s111 (two players l
 canonical corpse, one take wins, by net id), s112 (a client heal sticks against the peer's bars --
 FAILED twice first: the heal was reset before it was reported, then the avatar's stat write
 threw in a pcall), s113 (a cast costs magicka and a potion restores it -- FAILED first: an echoed
-report refilled the bar), s95 (play with friends -- FAILED first: every
+report refilled the bar), s114 (a recruited NPC follows the player on the OTHER player's
+screen -- FAILED first: companion.lua was never on an NPC), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
@@ -129,8 +130,8 @@ scenario is a code trace only.
 | Dialogue (one at a time) | dialogue lock; refusal names the holder | OK |
 | Persuasion (bribe/taunt/admire) | lock holder relays disposition | FIXED 09-11 |
 | Taunt -> fight; resist arrest -> fight | lock holder claims combat; holder starts it | FIXED 09-11 |
-| Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors | FIXED 09-10/11 |
-| Dialogue-started AiTravel | companion.lua reports; lock holder claim | FIXED 09-11 |
+| Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors. companion.lua was listed on two lines (NPC, CREATURE) and the engine keeps the last: NO NPC carried it until 09-12 -- every claim below was creature-only | FIXED 09-10/11, REALLY FIXED 09-12. Live: s114 |
+| Dialogue-started AiTravel | companion.lua reports; lock holder claim (see the two-lines note above: dead on NPCs until 09-12) | FIXED 09-11/12 |
 | Dialogue-started AiWander / AiActivate | not relayed; the holder's copy keeps its own package (cosmetic: an NPC told to stand still by a dialogue keeps wandering elsewhere) | OK (cosmetic) |
 | Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11 |
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |

--- a/server/src/core/worldstate.ts
+++ b/server/src/core/worldstate.ts
@@ -524,6 +524,7 @@ export class WorldState {
       }
       this.followedBy.set(ref.key, { ref, cellKey, follow, ...(escort ? { escort } : {}) });
     }
+    log('info', 'actor.follow_claim', { from: player.name, cellKey, key: ref.key, follow: follow ?? null, escort: escort !== undefined });
     this.relayCellExcept(cellKey, player.id, 'ActorAI', { ...lToJs(body) as Record<string, JsLike> });
   }
 

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -591,5 +591,26 @@ for _, path in ipairs(mpFiles) do
   check(path:match('([^/]+)$') .. ' calls no local function above its declaration', #bad == 0, table.concat(bad, '; '))
 end
 
+-- ============================================ mp.omwscripts: one line per script path
+-- The engine keeps only the LAST line naming a path (components/lua/configuration.cpp), so
+-- `NPC: x.lua` followed by `CREATURE: x.lua` attaches x.lua to creatures only. companion.lua
+-- sat like that for weeks: no NPC ever carried it, and no companion ever followed anyone.
+print('mp.omwscripts -- every script path is listed once')
+do
+  local f = io.open('./openmw/files/data/mp.omwscripts'); local cfg = f:read('*a'); f:close()
+  local seen, dups = {}, {}
+  for line in cfg:gmatch('[^' .. string.char(10) .. ']+') do
+    line = line:gsub(string.char(13) .. '$', '')
+    if not line:match('^%s*#') and not line:match('^%s*%+') then
+      local path = line:match(':%s*(%S+%.lua)%s*$')
+      if path then
+        if seen[path] then dups[#dups + 1] = path end
+        seen[path] = true
+      end
+    end
+  end
+  check('no script path appears on two lines (the first is silently dropped)', #dups == 0, table.concat(dups, ', '))
+end
+
 print(string.format('\n%d passed, %d failed', pass, fail))
 os.exit(fail == 0 and 0 or 1)

--- a/wasm-build/mp-harness.mjs
+++ b/wasm-build/mp-harness.mjs
@@ -295,6 +295,9 @@ function startSimPeer(port, password, cellKey, gameDataDir, watch) {
     if (existsSync(peerScripts)) {
       rmSync(peerScripts, { recursive: true, force: true });
       cpSync(join(ROOT, 'openmw', 'files', 'data', 'scripts', 'mp'), peerScripts, { recursive: true });
+      // The script LIST too: which types carry which script is part of what is under test
+      // (companion.lua on NPCs was a one-line change to this file).
+      cpSync(join(ROOT, 'openmw', 'files', 'data', 'mp.omwscripts'), join(dirname(dirname(peerScripts)), 'mp.omwscripts'));
     }
   } catch (e) {
     console.log(`[harness] WARNING: could not sync mp scripts into the peer (${e.message}). `

--- a/wasm-build/mp-scenarios/s114-companion.mjs
+++ b/wasm-build/mp-scenarios/s114-companion.mjs
@@ -31,6 +31,11 @@ export default async function run(ctx) {
   const start = pa[rec];
   ctx.log(`A recruits "${rec}" at (${Math.round(start.x)},${Math.round(start.y)})`);
 
+  // Stand beside them first: you recruit by talking, and AiFollow activates only with the
+  // target in range and in sight (mwmechanics/aifollow.cpp), on the peer where the avatar is.
+  await a.cmd(`snapto:${Math.round(start.x + 80)},${Math.round(start.y)},${Math.round(start.z + 8)}`);
+  await ctx.sleep(4_000);
+
   // Recruit: the dialogue result (Follow stacked on A's copy of the NPC). The conversation
   // itself pauses the game, and companion.lua only polls once it is closed -- as in play,
   // where the claim goes out after Goodbye. The server admits a follow claim on proximity.
@@ -39,14 +44,7 @@ export default async function run(ctx) {
   await a.cmd(`followprobe:${rec}`);
   await ctx.sleep(1_000);
   ctx.log(`A followProbe=${await a.eval('window.omw.state.followProbe')}`);
-  const creature = Object.keys(pa).find((r) => /mudcrab|scrib|rat|slaughterfish|kwama/.test(r));
-  if (creature) {
-    await a.cmd(`followprobe:${creature}`); await ctx.sleep(1_000);
-    ctx.log(`A followProbe on creature ${creature}=${await a.eval('window.omw.state.followProbe')}`);
-  }
   ctx.log('A luaErrors: ' + a.luaErrors().slice(-6).join(' || '));
-  const tail = (a.logTail ? a.logTail(80) : '').split(String.fromCharCode(10)).filter((l) => !/Local map|navmesh|audio/.test(l)).slice(-25);
-  ctx.log('A tail: ' + tail.join(' || '));
 
   // Walk away -- to the spawn point, known dry land (an arbitrary offset put A in the bay).
   // The companion must come along -- on B's screen, which did nothing.

--- a/wasm-build/mp-scenarios/s114-companion.mjs
+++ b/wasm-build/mp-scenarios/s114-companion.mjs
@@ -1,0 +1,57 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s114: A COMPANION FOLLOWS YOU, ON EVERYONE'S SCREEN. Recruiting is a dialogue result that
+// runs on the recruiting player's own client, whose copy of the NPC is a puppet with its AI
+// off. So the fact is born on a non-holder: companion.lua on that puppet notices the Follow
+// package, the client claims "this one follows ME" (ActorAI; the server admits it from the
+// player who holds the NPC's dialogue lock), the holder starts the package on ITS NPC, and
+// the pose stream carries the companion to every other screen. Several main-quest arcs hand
+// you a companion; before this chain existed the follower moved for the recruiter alone.
+//
+// Live proof: A talks to an NPC, recruits it, walks off; B -- who did nothing -- sees the NPC
+// arrive next to A.
+import assert from 'node:assert/strict';
+
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const dist2 = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) {
+    await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, `${c.name} puppeted the cell actors (the peer holds it)`);
+  }
+  // A living NPC both see, that is not a guard (guards have their own ideas).
+  const [pa, pb] = await Promise.all([probeOf(a), probeOf(b)]);
+  const rec = Object.keys(pa).find((r) => r !== 'player' && pb[r] && !pa[r].dead && !pa[r].guard);
+  assert.ok(rec, 'need a living NPC visible to both clients');
+  const start = pa[rec];
+  ctx.log(`A recruits "${rec}" at (${Math.round(start.x)},${Math.round(start.y)})`);
+
+  // Recruit: the conversation (dialogue lock) and the dialogue result (Follow on A's copy).
+  await a.cmd(`dlg:${rec}`);
+  await ctx.sleep(1_500);
+  await a.cmd(`follow:${rec}`);
+  await ctx.sleep(2_500); // companion.lua polls at 1 Hz; the claim needs the lock still held
+  await a.cmd('dlg:release');
+
+  // Walk away. The companion must come along -- on B's screen, which did nothing.
+  const dest = { x: start.x + 900, y: start.y + 300, z: start.z + 32 };
+  await a.cmd(`snapto:${Math.round(dest.x)},${Math.round(dest.y)},${Math.round(dest.z)}`);
+  const deadline = Date.now() + 90_000;
+  let dB = Infinity, dA = Infinity;
+  while (Date.now() < deadline) {
+    const [qa, qb] = await Promise.all([probeOf(a), probeOf(b)]);
+    if (qa[rec]) dA = dist2(qa[rec], dest);
+    if (qb[rec]) dB = dist2(qb[rec], dest);
+    if (dB < 350 && dA < 350) break;
+    await ctx.sleep(1_000);
+  }
+  ctx.log(`companion distance to A after the walk: on A ${Math.round(dA)}, on B ${Math.round(dB)} (started ${Math.round(dist2(start, dest))} away)`);
+  assert.ok(dB < 350, `B never saw "${rec}" follow A (${Math.round(dB)} units away): the recruit claim did not reach the holder, or the holder's follower is not relayed`);
+  assert.ok(dA < 350, `A's own copy of "${rec}" did not arrive (${Math.round(dA)} units away)`);
+  ctx.log(`ok: "${rec}" followed A, and B saw it come`);
+}

--- a/wasm-build/mp-scenarios/s114-companion.mjs
+++ b/wasm-build/mp-scenarios/s114-companion.mjs
@@ -36,6 +36,17 @@ export default async function run(ctx) {
   // where the claim goes out after Goodbye. The server admits a follow claim on proximity.
   await a.cmd(`follow:${rec}`);
   await ctx.sleep(2_500); // companion.lua polls at 1 Hz
+  await a.cmd(`followprobe:${rec}`);
+  await ctx.sleep(1_000);
+  ctx.log(`A followProbe=${await a.eval('window.omw.state.followProbe')}`);
+  const creature = Object.keys(pa).find((r) => /mudcrab|scrib|rat|slaughterfish|kwama/.test(r));
+  if (creature) {
+    await a.cmd(`followprobe:${creature}`); await ctx.sleep(1_000);
+    ctx.log(`A followProbe on creature ${creature}=${await a.eval('window.omw.state.followProbe')}`);
+  }
+  ctx.log('A luaErrors: ' + a.luaErrors().slice(-6).join(' || '));
+  const tail = (a.logTail ? a.logTail(80) : '').split(String.fromCharCode(10)).filter((l) => !/Local map|navmesh|audio/.test(l)).slice(-25);
+  ctx.log('A tail: ' + tail.join(' || '));
 
   // Walk away -- to the spawn point, known dry land (an arbitrary offset put A in the bay).
   // The companion must come along -- on B's screen, which did nothing.

--- a/wasm-build/mp-scenarios/s114-companion.mjs
+++ b/wasm-build/mp-scenarios/s114-companion.mjs
@@ -31,15 +31,15 @@ export default async function run(ctx) {
   const start = pa[rec];
   ctx.log(`A recruits "${rec}" at (${Math.round(start.x)},${Math.round(start.y)})`);
 
-  // Recruit: the conversation (dialogue lock) and the dialogue result (Follow on A's copy).
-  await a.cmd(`dlg:${rec}`);
-  await ctx.sleep(1_500);
+  // Recruit: the dialogue result (Follow stacked on A's copy of the NPC). The conversation
+  // itself pauses the game, and companion.lua only polls once it is closed -- as in play,
+  // where the claim goes out after Goodbye. The server admits a follow claim on proximity.
   await a.cmd(`follow:${rec}`);
-  await ctx.sleep(2_500); // companion.lua polls at 1 Hz; the claim needs the lock still held
-  await a.cmd('dlg:release');
+  await ctx.sleep(2_500); // companion.lua polls at 1 Hz
 
-  // Walk away. The companion must come along -- on B's screen, which did nothing.
-  const dest = { x: start.x + 900, y: start.y + 300, z: start.z + 32 };
+  // Walk away -- to the spawn point, known dry land (an arbitrary offset put A in the bay).
+  // The companion must come along -- on B's screen, which did nothing.
+  const dest = { x: -12288, y: -69632, z: 87 };
   await a.cmd(`snapto:${Math.round(dest.x)},${Math.round(dest.y)},${Math.round(dest.z)}`);
   const deadline = Date.now() + 90_000;
   let dB = Infinity, dA = Infinity;
@@ -50,6 +50,9 @@ export default async function run(ctx) {
     if (dB < 350 && dA < 350) break;
     await ctx.sleep(1_000);
   }
+  const mpLines = (a.logTail ? a.logTail(600) : '').split(String.fromCharCode(10)).filter((l) => /follow|Follow|mpTestFollow|ActorAI/i.test(l)).slice(-8);
+  ctx.log('A follow-related tail: ' + mpLines.join(' || '));
+  ctx.log(`A testFollow=${await a.eval('window.omw.state.testFollow')} companionReport=${await a.eval('window.omw.state.companionReport')} followClaim=${await a.eval('window.omw.state.followClaim')}`);
   ctx.log(`companion distance to A after the walk: on A ${Math.round(dA)}, on B ${Math.round(dB)} (started ${Math.round(dist2(start, dest))} away)`);
   assert.ok(dB < 350, `B never saw "${rec}" follow A (${Math.round(dB)} units away): the recruit claim did not reach the holder, or the holder's follower is not relayed`);
   assert.ok(dA < 350, `A's own copy of "${rec}" did not arrive (${Math.round(dA)} units away)`);


### PR DESCRIPTION
## What this pass found
**s114** (A recruits an NPC, walks off, and B sees it arrive) failed with the Follow package stacked on A's copy and nothing reported. An AI-stack probe answered from a creature and never from an NPC: `mp.omwscripts` listed `companion.lua` on two lines (`NPC:` then `CREATURE:`) and `components/lua/configuration.cpp` keeps only the **last** line naming a script path. So the script that carries every companion, escort, scripted-travel and combat-state claim — and, since PR #44, the handoff-snapshot bars — was on creatures only. No companion has ever followed anyone on another screen.

## Fix
- `mp.omwscripts`: one line, `NPC,CREATURE: scripts/mp/companion.lua`.
- Lua runner: a static check that no script path appears on two lines (fails on the old file; 114/114 now).
- `mp-harness`: the peer receives the working tree's `mp.omwscripts` as well as `scripts/mp`.
- s114 keeps follow-chain mirrors (`testFollow`, `companionReport`, `followClaim`, `followProbe`), the server logs `actor.follow_claim`, the peer prints the claim it applies. Recruiting happens beside the NPC (AiFollow activates only in range and in sight).

## Gates
- s114 PASS (Fargoth followed A 2694 units and B saw it come); s51 s61 s78 s72 s31 s21 s109 s112 PASS on the engine baked from this branch.
- tsc clean; server suite 1070 tests, 0 fail; Lua runner 114/114. No engine C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)