### PR TITLE
Gameplay pass: summons stand on every screen (s115), spells at other players land (s116)

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2332,7 +2332,12 @@ local eventHandlers = {
     -- without this there is no automated way to exercise it at all.
     mpTestCastAt = function(data)
         local victim = nil
+        if data.playerId then
+            local p = puppets[data.playerId]
+            victim = p and p.obj:isValid() and p.obj or nil
+        end
         for _, obj in ipairs(world.activeActors) do
+            if victim then break end
             if obj:isValid() and obj.recordId == data.record then victim = obj break end
         end
         if not victim then
@@ -2377,6 +2382,21 @@ local eventHandlers = {
         else
             mp.set('castAt', 'cast:' .. tostring(testCastSpellId))
         end
+    end,
+
+    -- Cast a spell on YOURSELF, the way the engine records it: an active spell on the player
+    -- (a summon, a buff). Whether it does anything depends on the owner->avatar channel.
+    mpTestSelfCast = function(data)
+        local player = playerScript()
+        if not player then return end
+        local ok, err = pcall(function()
+            local spell = core.magic.spells.records[data.id]
+            if not spell then error('no such spell: ' .. tostring(data.id)) end
+            local indexes = {}
+            for i = 1, #spell.effects do indexes[i] = i - 1 end
+            types.Actor.activeSpells(player):add({ id = data.id, effects = indexes, caster = player })
+        end)
+        pcall(function() mp.set('selfCast', ok and ('cast:' .. tostring(data.id)) or ('failed:' .. tostring(err))) end)
     end,
 
     -- M4 test hook: kill a specific cell NPC (holder side drives the death edge).

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -635,6 +635,16 @@ local function dispatch(cmd)
         if castRec then
             core.sendGlobalEvent('mpTestCastAt', { record = castRec, magnitude = tonumber(castMag) })
         end
+        -- castp:<playerId>:<magnitude>: the same magic path at another PLAYER's puppet (s116).
+        local castPid, castPMag = cmd:match('^castp:(%d+):([%d.]+)$')
+        if castPid then
+            core.sendGlobalEvent('mpTestCastAt', { playerId = tonumber(castPid), magnitude = tonumber(castPMag) })
+        end
+        -- selfcast:<spellId>: what casting a spell on yourself does locally -- an active spell
+        -- on the player's own body (a summon, a buff). The avatar receives it through
+        -- PlayerActiveSpells and the peer acts on it (s115).
+        local selfSpell = cmd:match('^selfcast:(.+)$')
+        if selfSpell then core.sendGlobalEvent('mpTestSelfCast', { id = selfSpell }) end
         local killNpc = cmd:match('^killnpc:(.+)$')
         if killNpc then core.sendGlobalEvent('mpKillNpc', { id = killNpc }) end
         if cmd == 'door:toggle' then core.sendGlobalEvent('mpDoorToggle', {}) end

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -28,7 +28,10 @@ canonical corpse, one take wins, by net id), s112 (a client heal sticks against 
 FAILED twice first: the heal was reset before it was reported, then the avatar's stat write
 threw in a pcall), s113 (a cast costs magicka and a potion restores it -- FAILED first: an echoed
 report refilled the bar), s114 (a recruited NPC follows the player on the OTHER player's
-screen -- FAILED first: companion.lua was never on an NPC), s95 (play with friends -- FAILED first: every
+screen -- FAILED first: companion.lua was never on an NPC), s115 (a conjurer's Summon Scamp
+stands on both screens as one net actor: owner active spell -> avatar -> peer summons -> named),
+s116 (a spell at another player: parked on the puppet, forwarded, applied to the avatar, bars
+back), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/wasm-build/mp-scenarios/s115-summon.mjs
+++ b/wasm-build/mp-scenarios/s115-summon.mjs
@@ -1,0 +1,40 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s115: A CONJURER'S SUMMON IS REAL FOR EVERYONE. Casting Summon Scamp puts an active spell on
+// the caster's OWN body. On a simulated world the client does not spawn the creature (the
+// spawn gate, s109); the spell rides PlayerActiveSpells to the avatar, the peer's engine
+// summons the scamp beside the avatar, names it (s107), and every client builds it. If any
+// hop is broken a conjurer's whole playstyle is a spell that does nothing.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const SPELL = 'summon scamp';
+const netObjs = async (c) => JSON.parse(await c.eval('window.omw.state.netObjects||"{}"'));
+const summoned = (objs) => Object.entries(objs).find(([, rec]) => /scamp/i.test(String(rec)));
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) await c.waitFor('window.omw.state.state === "Joined"', 60_000, `${c.name} joined`);
+  await a.waitFor('window.omw.state.localSpawns === "off"', 60_000, 'A is not spawning its own creatures (simulated world)');
+  const before = summoned(await netObjs(a));
+  assert.ok(!before, `a scamp is already named before the cast: ${JSON.stringify(before)}`);
+
+  await a.cmd(`selfcast:${SPELL}`);
+  await a.waitFor('String(window.omw.state.selfCast||"").indexOf("cast:") === 0', 15_000, 'the spell is active on A');
+  ctx.log(`A selfCast=${await a.eval('window.omw.state.selfCast')}`);
+
+  const deadline = Date.now() + 60_000;
+  let onA = null, onB = null;
+  while (Date.now() < deadline && !(onA && onB)) {
+    onA = summoned(await netObjs(a)); onB = summoned(await netObjs(b));
+    if (onA && onB) break;
+    await ctx.sleep(1_000);
+  }
+  ctx.log(`scamp on A=${JSON.stringify(onA)} on B=${JSON.stringify(onB)}; A netObjects=${await a.eval('window.omw.state.netObjects')}`);
+  assert.ok(onA, 'the caster never saw their own scamp: the active spell did not reach the avatar, or the peer did not summon, or it was not named');
+  assert.ok(onB, 'the other player never saw the scamp: it was not named for everyone');
+  assert.equal(onA[0], onB[0], 'both see the same net id');
+  ctx.log(`ok: "${onA[1]}" (net ${onA[0]}) stands on both screens`);
+}

--- a/wasm-build/mp-scenarios/s116-magic-pvp.mjs
+++ b/wasm-build/mp-scenarios/s116-magic-pvp.mjs
@@ -1,0 +1,44 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s116: A SPELL AT ANOTHER PLAYER. s66 proves a sword; this is the magic path, which is a
+// different one entirely: the engine applies spell damage itself (mwmechanics/spelleffects.cpp),
+// so the attacker's engine parks the effect on the victim's PUPPET (mwmp/puppets.hpp), the
+// puppet script drains and forwards it (CombatSpellHit {playerId}), the server routes it to
+// the peer because the victim is driving, and the peer applies it to the victim's avatar --
+// whose bars come back to the victim as SelfStats. PvP on.
+import assert from 'node:assert/strict';
+
+export const serverRules = `
+[content]
+enforce = "off"
+[rules]
+pvp = true
+`;
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const parseBars = (s) => { const m = /^(\d+)\/(\d+)$/.exec(String(s ?? '')); return m ? { c: Number(m[1]), b: Number(m[2]) } : null; };
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [victim, attacker] = await Promise.all([ctx.launchClient('victim', '', BOOT), ctx.launchClient('attacker', '', BOOT)]);
+  await victim.waitFor('String(window.omw.state.selfStats||"").indexOf("/") > 0', 300_000, 'the peer reports the victim\'s bars (driving)');
+  await victim.waitFor('Number(window.omw.state.playerId||0) > 0', STEP, 'victim knows its id');
+  const victimId = Number(await victim.eval('window.omw.state.playerId'));
+  await attacker.waitFor('window.omw.state.pvp === "true"', STEP, 'attacker sees pvp enabled');
+  await attacker.waitFor(`Object.keys(JSON.parse(window.omw.state.puppets||"{}")).includes(String(${victimId}))`, STEP, 'attacker puppets the victim');
+  const before = parseBars(await victim.eval('window.omw.state.selfStats'));
+  ctx.log(`victim id=${victimId}, bars ${before.c}/${before.b}; casting`);
+
+  const deadline = Date.now() + 60_000;
+  let bars = null, dropped = false;
+  while (Date.now() < deadline && !dropped) {
+    await attacker.cmd(`castp:${victimId}:15`);
+    await ctx.sleep(1_500);
+    bars = parseBars(await victim.eval('window.omw.state.selfStats'));
+    dropped = !!bars && bars.c < before.c;
+  }
+  ctx.log(`victim bars after: ${bars ? bars.c + '/' + bars.b : 'none'}; attacker castAt=${await attacker.eval('window.omw.state.castAt')} magicFwd=${await attacker.eval('window.omw.state.magicFwd')} spellFwd=${await attacker.eval('window.omw.state.spellFwd')}`);
+  assert.ok(dropped, 'the victim\'s peer-reported bars never dropped from a spell: the magic path to another player is broken somewhere between the parked effect and the avatar');
+  ctx.log(`ok: a spell at another player landed on their avatar (${before.c} -> ${bars.c})`);
+}


### PR DESCRIPTION
## Live proof, no product fix needed this time
- **s115** Summon Scamp cast by A: the active spell rides to the avatar, the peer summons, the scamp is named once and both clients build it (net 2, `scamp_summon`). PASS first run.
- **s116** a spell at another player (PvP on): parked on the puppet, forwarded as CombatSpellHit, applied to the victim's avatar, bars back as SelfStats (35 -> 0). PASS first run.
- Test hooks: `selfcast:<spellId>` (an active spell on your own body), `castp:<playerId>:<n>` (the magic path at a player puppet).

## Gates
- Lua runner 114/114; tsc clean; no server or engine C++ changes (hooks are client Lua).

🤖 Generated with [Claude Code](https://claude.com/claude-code)