### PR TITLE
Harness: the server's own peer lifecycle under test (managedPeer); s118 a fight indoors

### DIFF
--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -32,7 +32,8 @@ screen -- FAILED first: companion.lua was never on an NPC), s115 (a conjurer's S
 stands on both screens as one net actor: owner active spell -> avatar -> peer summons -> named),
 s116 (a spell at another player: parked on the puppet, forwarded, applied to the avatar, bars
 back), s117 (a companion comes indoors with you through a load door and your friend finds
-you both there), s95 (play with friends -- FAILED first: every
+you both there), s118 (a fight INDOORS: the peer holds the room as an anchor -- the first scenario
+to run the server's own peer lifecycle, `managedPeer`; a hand-spawned peer never anchors a room), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/wasm-build/mp-harness.mjs
+++ b/wasm-build/mp-harness.mjs
@@ -13,7 +13,7 @@
 // kills ONLY the PIDs this harness spawned — never any pkill pattern (repo hard rule: the
 // user's real Chrome must be untouchable; every client runs in a throwaway --user-data-dir).
 import { spawn, execSync } from 'node:child_process';
-import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync, statSync, symlinkSync } from 'node:fs';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -75,7 +75,7 @@ async function waitHttp(url, timeoutMs, what) {
 // OMW_WORLD_MODE / OMW_WORLD_ID) rather than config-driven, so it cannot be set through
 // serverRules. Exported as a function receiving the run id, because an owner is an ACCOUNT
 // NAME and account names carry the run-id suffix.
-async function startGameServer(extraRules = '', extraEnv = {}) {
+async function startGameServer(extraRules = '', extraEnv = {}, opts = {}) {
   // testhost.mjs, NOT server.mjs. main.ts refuses to boot without real game data, a peer
   // binary and a server password (the tier-2 mandate) — right for a deployment, fatal for a
   // harness whose whole point is a throwaway data dir with none of those. When that landed,
@@ -127,6 +127,23 @@ async function startGameServer(extraRules = '', extraEnv = {}) {
     // patched it locally; it belongs here, once, for every scenario.
     ['limits', ['maxConnsPerIp = 64', 'loginPerMinPerIp = 100000']],
   ]);
+  // THE SERVER'S OWN SIM PEER (`export const managedPeer = true`). Every other scenario
+  // spawns a peer by hand at one cell; that never exercises the production lifecycle --
+  // simPeerPass anchoring every occupied cell, INTERIORS held as room anchors, restart and
+  // reaping -- so a room nobody simulated (s118) was invisible to the harness. With this the
+  // server sees game data, spawns the peer itself and anchors wherever the players go.
+  if (opts.managedPeer && process.env.OMW_SIM_PEER_BIN && existsSync(process.env.OMW_SIM_PEER_BIN)) {
+    syncPeerScripts();
+    const gd = join(ROOT, 'play', 'mwdata');
+    try { symlinkSync(gd, join(dataDir, 'gamedata'), 'dir'); } catch (e) { console.log('[harness] gamedata symlink failed: ' + e.message); }
+    sections.set('simPeer', [
+      `binary = ${JSON.stringify(process.env.OMW_SIM_PEER_BIN)}`,
+      `configDir = ${JSON.stringify(join(dataDir, 'peer-config'))}`,
+      `userDataDir = ${JSON.stringify(join(dataDir, 'peer-user'))}`,
+      'startCell = "-2,-9"', 'maxPeers = 1', 'anchorIdleSec = 60', 'idleReapMs = 600000',
+      'startTimeoutMs = 240000', 'restartBackoffMs = 5000',
+    ]);
+  }
   // Default section is `rules`: scenarios predating the merge export a bare key
   // (`serverRules = 'pvp = true'`) because the old writer appended straight after the
   // [rules] table. Honour that implicit contract rather than throwing — otherwise those
@@ -256,6 +273,24 @@ async function ensurePlayServer() {
 // declaring it aborts startup with "Content file specified more than once", which is a
 // confusing way to spend an afternoon. Keep this in step with buildPeerCfg rather than
 // inventing a second config.
+// THE PEER MUST RUN THE SCRIPTS UNDER TEST, not the ones baked into its image (see the note
+// in startSimPeer). Shared by the hand-spawned peer and the server-managed one.
+function syncPeerScripts() {
+  const peerScripts = '/usr/local/share/openmw/resources/vfs/scripts/mp';
+  try {
+    if (existsSync(peerScripts)) {
+      rmSync(peerScripts, { recursive: true, force: true });
+      cpSync(join(ROOT, 'openmw', 'files', 'data', 'scripts', 'mp'), peerScripts, { recursive: true });
+      // The script LIST too: which types carry which script is part of what is under test
+      // (companion.lua on NPCs was a one-line change to this file).
+      cpSync(join(ROOT, 'openmw', 'files', 'data', 'mp.omwscripts'), join(dirname(dirname(peerScripts)), 'mp.omwscripts'));
+    }
+  } catch (e) {
+    console.log(`[harness] WARNING: could not sync mp scripts into the peer (${e.message}). `
+      + 'The peer will run its baked copy, so client-script changes will not be under test.');
+  }
+}
+
 function startSimPeer(port, password, cellKey, gameDataDir, watch) {
   const bin = process.env.OMW_SIM_PEER_BIN;
   if (!bin || !existsSync(bin)) return null;
@@ -290,19 +325,7 @@ function startSimPeer(port, password, cellKey, gameDataDir, watch) {
   // correctly and the peer fails on old code, so the feature looks broken in a way that points
   // at neither. Cost several rebuild cycles to spot — a 0-based index fix in combat.lua looked
   // inert because only half the fleet had it.
-  const peerScripts = '/usr/local/share/openmw/resources/vfs/scripts/mp';
-  try {
-    if (existsSync(peerScripts)) {
-      rmSync(peerScripts, { recursive: true, force: true });
-      cpSync(join(ROOT, 'openmw', 'files', 'data', 'scripts', 'mp'), peerScripts, { recursive: true });
-      // The script LIST too: which types carry which script is part of what is under test
-      // (companion.lua on NPCs was a one-line change to this file).
-      cpSync(join(ROOT, 'openmw', 'files', 'data', 'mp.omwscripts'), join(dirname(dirname(peerScripts)), 'mp.omwscripts'));
-    }
-  } catch (e) {
-    console.log(`[harness] WARNING: could not sync mp scripts into the peer (${e.message}). `
-      + 'The peer will run its baked copy, so client-script changes will not be under test.');
-  }
+  syncPeerScripts();
   const proc = spawn(bin, [
     '--config', cfgDir, '--replace', 'config', '--user-data', userDir,
     '--skip-menu', '--start', cellKey, '--no-sound',
@@ -756,10 +779,10 @@ for (const file of files) {
   console.log(`\n=== scenario ${file} ===`);
   try {
     // Import first: a scenario may declare server rules it needs (e.g. pvp = true).
-    const { default: run, serverRules, serverEnv, critical } = await import(pathToFileURL(join(SCENARIO_DIR, file)));
+    const { default: run, serverRules, serverEnv, critical, managedPeer } = await import(pathToFileURL(join(SCENARIO_DIR, file)));
     isCritical = !!critical;
     const envForRun = typeof serverEnv === 'function' ? serverEnv(RUN_ID) : (serverEnv ?? {});
-    server = await startGameServer(serverRules, envForRun);
+    server = await startGameServer(serverRules, envForRun, { managedPeer: !!managedPeer });
     await run({
       // CAPTURE ANY CHILD A SCENARIO SPAWNS. Gateways were started with stdio:'ignore', so a
       // gateway that came up healthy while every world it spawned crashed on startup looked
@@ -785,7 +808,11 @@ for (const file of files) {
       // A REAL simulating peer, for scenarios that need NPCs to move rather than just a cell to
       // have an owner. Returns null when the binary is absent (the plain harness image), so a
       // scenario can skip cleanly instead of failing.
-      startSimPeer: (cellKey, gameDataDir) => startSimPeer(
+      // Under `managedPeer` the SERVER spawns and anchors it (simPeerPass); the call is
+      // answered so the scenario's skip-guard sees a peer, and nothing is spawned twice.
+      startSimPeer: (cellKey, gameDataDir) => (managedPeer && process.env.OMW_SIM_PEER_BIN && existsSync(process.env.OMW_SIM_PEER_BIN))
+        ? { managed: true, stop: () => {} }
+        : startSimPeer(
         server.port, SERVER_PASSWORD, cellKey,
         gameDataDir ?? join(ROOT, 'play', 'mwdata'),
         (label, proc) => {

--- a/wasm-build/mp-scenarios/s118-indoor-fight.mjs
+++ b/wasm-build/mp-scenarios/s118-indoor-fight.mjs
@@ -1,0 +1,58 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s118: A FIGHT INDOORS. s51 proves shared NPC combat under the open sky, where the peer's
+// avatar stands in the cell it simulates. An interior is different: it has no grid
+// coordinate, so the peer holds it as a ROOM anchor (MP_SimAnchors) -- loaded and ticked
+// without the peer's own body inside -- and every relay addresses it by name. Two players walk
+// through the same door, both hit the same NPC, and it dies once, for both.
+import assert from 'node:assert/strict';
+
+// THE SERVER'S OWN PEER. A hand-spawned peer stands in one exterior cell and never anchors a
+// room; only the production lifecycle (server.ts simPeerPass -> SimAnchors interiors) holds an
+// interior, so this is the first scenario to run it. (Found by this scenario: with the
+// hand-spawned peer the tradehouse never had a holder at all.)
+export const managedPeer = true;
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const cellOf = async (c) => String(await c.eval('window.omw.state.cell||""'));
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, `${c.name} puppeted the cell actors`);
+  const outside = await cellOf(a);
+  for (const c of [a, b]) {
+    await c.cmd('door:enter');
+    await c.waitFor(`String(window.omw.state.cell||"") !== ${JSON.stringify(outside)}`, STEP, `${c.name} went through the door`);
+  }
+  const inside = await cellOf(a);
+  assert.equal(await cellOf(b), inside, 'both are in the same interior');
+  ctx.log(`both inside "${inside}"`);
+
+  // The room is simulated: somebody holds it and both puppet its actors.
+  for (const c of [a, b]) {
+    await c.waitFor('String(window.omw.state.authorityHolder||"none") !== "none"', 120_000, `${c.name}: the interior has a holder`);
+    await c.waitFor('window.omw.state.isHolder === "false"', STEP, `${c.name} does not hold it (the peer does)`);
+  }
+  const [pa, pb] = await Promise.all([probeOf(a), probeOf(b)]);
+  const victim = Object.keys(pa).find((r) => r !== 'player' && pb[r] && !pa[r].dead && !pa[r].guard);
+  assert.ok(victim, `need a living NPC inside visible to both: A=${JSON.stringify(Object.keys(pa))} B=${JSON.stringify(Object.keys(pb))}`);
+  ctx.log(`both attacking "${victim}" indoors (holder=${await a.eval('window.omw.state.authorityHolder')})`);
+
+  const deadExpr = `((JSON.parse(window.omw.state.actorProbe||"{}")[${JSON.stringify(victim)}]||{}).dead === true)`;
+  const deadline = Date.now() + 90_000;
+  let died = false;
+  while (Date.now() < deadline && !died) {
+    await a.cmd(`hitn:${victim}:40`);
+    await b.cmd(`hitn:${victim}:40`);
+    await ctx.sleep(600);
+    died = (await a.eval(deadExpr)) === true || (await b.eval(deadExpr)) === true;
+  }
+  ctx.log(`hitFwd A=${await a.eval('window.omw.state.hitFwd')} B=${await b.eval('window.omw.state.hitFwd')}`);
+  assert.ok(died, `"${victim}" never died indoors: hits are not reaching the room's holder, or the peer does not simulate the room`);
+  await a.waitFor(deadExpr, STEP, 'A sees it dead');
+  await b.waitFor(deadExpr, STEP, 'B sees it dead');
+  ctx.log(`ok: "${victim}" died once indoors, for both players`);
+}


### PR DESCRIPTION
## What this pass found
**s118** (two players fight an NPC inside Arrille's Tradehouse) never got a holder for the room. Every scenario spawns its peer by hand, standing in one exterior cell — the production lifecycle (server.ts `simPeerPass` anchoring every occupied cell, **interiors as room anchors**, restart, reaping) had no live coverage at all.

## Harness
`export const managedPeer = true`: the harness gives the server game data (play/mwdata symlinked as gamedata), a `[simPeer]` section pointing at `OMW_SIM_PEER_BIN`, and lets the server spawn and anchor the peer itself; `ctx.startSimPeer` answers without spawning a second one. Peer scripts are synced from the tree in both modes.

## Live proof
- **s118** PASS under managedPeer: the room gets a holder that is not a client, both hit the same NPC, it dies once for both.
- Hand-spawned mode unchanged: s51 s117 s69 s41 PASS.

No server or engine changes; Lua runner 114/114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)