### PR TITLE
Gameplay pass: a level-up mid-session never reached the avatar (s121)

### DIFF
--- a/openmw/files/data/scripts/mp/identity.lua
+++ b/openmw/files/data/scripts/mp/identity.lua
@@ -160,7 +160,7 @@ local tracked = {
     hp = { stat = 'health', gainsOnly = true },
     mp = { stat = 'magicka', gainsOnly = false },
 }
-for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
+for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0; t.baseSaid = nil end
 local peerBarsAt = nil -- when the peer last reported; past PEER_RULES_S our own bars rule again
 local PEER_RULES_S = 5 -- server/src/core/players.ts INPUT_DRIVING_MS, the same predicate
 function identity.notePeerBars(hp, mpv, ft)
@@ -352,10 +352,15 @@ function identity.tick(now)
             -- fresh claim: the bite undone, the cast refilled (s113).
             local claim, any = {}, false
             for k, t in pairs(tracked) do
-                if math.abs(t.delta) > 0.5 then
+                -- A changed MAXIMUM is a claim too (a level-up, endurance, intelligence): the
+                -- base is ours to say, and the avatar must get it or the new maximum exists
+                -- on no body that fights.
+                local baseMoved = t.baseSaid ~= nil and math.abs(dyn[k].b - t.baseSaid) > 0.5
+                if math.abs(t.delta) > 0.5 or baseMoved then
                     claim[k] = { c = math.floor(math.max(0, math.min(dyn[k].b, t.peer + t.delta)) + 0.5), b = dyn[k].b }
                     any = true
                 end
+                t.baseSaid = dyn[k].b
                 t.delta = 0
             end
             if any then mp.sendEvent('PlayerStatsDynamic', claim) end
@@ -470,7 +475,7 @@ end
 
 function identity.reset()
     last = {}
-    for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0 end
+    for _, t in pairs(tracked) do t.peer = nil; t.prev = nil; t.delta = 0; t.baseSaid = nil end
     peerBarsAt = nil
     -- nil, NOT {}: the next pass must re-seed the baseline rather than treat the whole restored
     -- inventory as newly acquired.

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -598,6 +598,11 @@ local function dispatch(cmd)
         if mpv then
             types.Actor.stats.dynamic.magicka(self).current = tonumber(mpv)
         end
+        -- sethpbase:<n>: what a level-up does to the maximum (s121).
+        local hpb = cmd:match('^sethpbase:(-?[%d.]+)$')
+        if hpb then
+            types.Actor.stats.dynamic.health(self).base = tonumber(hpb)
+        end
         local race, head, hair = cmd:match('^applyrace:([^:]+):([^:]+):([^:]*)$')
         if race then
             mp.applyChargen({ race = race, head = head, hair = hair, isMale = true })

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -35,7 +35,8 @@ back), s117 (a companion comes indoors with you through a load door and your fri
 you both there), s118 (a fight INDOORS: the peer holds the room as an anchor -- the first scenario
 to run the server's own peer lifecycle, `managedPeer`; a hand-spawned peer never anchors a room), s119 (the peer is killed; the server notices,
 restarts it, re-anchors the cell and a fight resolves under the new one), s120 (two players two
-cells apart: one peer, two anchors, both fights resolve), s95 (play with friends -- FAILED first: every
+cells apart: one peer, two anchors, both fights resolve), s121 (a level-up's new maximum reaches the
+avatar and a heal fills the new pool -- FAILED first: the base was thrown away while the peer ruled), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
@@ -99,7 +100,7 @@ scenario is a code trace only.
 | Action | MP path | Status |
 |---|---|---|
 | hp/mp/ft | peer-authored while driving; client may raise (heal); magicka client both ways. identity.lua measures the LOCAL change per frame and claims only the changed bars on top of the peer's last report (an echoed snapshot used to undo bites and refill casts; a heal was reset before the 4 Hz diff saw it) | FIXED 09-11 twice. Live: s112 (heal sticks), s113 (cast costs, potion restores) |
-| Attributes/skills/level, training, level-up | client diff -> doc -> AvatarState -> avatar.lua mpAvatarStats (Self context: every stat setter is Self-gated, the global-script write threw inside a pcall and the avatar stayed a level-1 template with a template health pool) | FIXED 09-11 |
+| Attributes/skills/level, training, level-up | client diff -> doc -> AvatarState -> avatar.lua mpAvatarStats; a level-up's new MAXIMUM health/magicka/fatigue is claimed by identity.lua and accepted server-side as a plausible base step (<=60, one per stat per 10 s), forwarded with the current preserved (was dropped while the peer ruled: the old pool stayed on the body that fights) (Self context: every stat setter is Self-gated, the global-script write threw inside a pcall and the avatar stayed a level-1 template with a template health pool) | FIXED 09-11 |
 | Skill use from cancelled swings | skill use runs before the Lua cancel | OK |
 | Diseases (caught) | AvatarEffectsBatch -> doc.spells + owner | FIXED 09-11 |
 | Vampirism / lycanthropy | spell list / appearance; werewolf form set on rebuilt bodies | FIXED 09-11 (looked human) |

--- a/server/src/core/players.ts
+++ b/server/src/core/players.ts
@@ -106,6 +106,8 @@ export interface Player {
   // health every tick and never dies. See playerstate.ts handleStatsDynamic.
   restoreWindowAt?: number;
   restoreInWindow?: number;
+  // When each bar's MAXIMUM last stepped (a level-up); one step per window per stat.
+  baseStepAt?: Partial<Record<'hp' | 'mp' | 'ft', number>>;
   // Where this player's last cell change / teleport claimed they landed. While set, the
   // peer's avatar poses are ignored for them: the avatar teleports on the RELAY of the cell
   // change, so its stream still says the old place for a while -- and one stale sample is a

--- a/server/src/core/playerstate.ts
+++ b/server/src/core/playerstate.ts
@@ -147,12 +147,39 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
     // A LOWER value is ignored: damage is peer-authored. Raises are capped at base. This is
     // the pre-input-tier trust boundary for healing, no wider; the intent tier narrows it.
     const cur = ctx.store.getCached(player.charId)?.stats?.dynamic;
+    // A LEVEL-UP RAISES THE MAXIMUM, AND ONLY THE CLIENT LEVELS UP. The base of a bar is a
+    // client-authored fact (level, endurance, intelligence -- all of them travel as client
+    // diffs already), and while the peer ruled the bars it was thrown away with the rest of
+    // the claim: a player who levelled mid-session kept the old maximum on the avatar, the
+    // body that actually fights, until they relogged. Accepted within a plausible step; a
+    // jump beyond it is the modified-client shape and is refused, loudly.
+    // A level in Morrowind adds at most a few dozen points, minutes apart; the budget is one
+    // step of that size per stat per window, so ramping the maximum 50 points a tick to
+    // 2000 and "healing" to it is refused at the second step.
+    const MAX_BASE = 2000, MAX_BASE_STEP = 60, BASE_STEP_WINDOW_MS = 10_000;
+    const newBase = (k: 'hp' | 'mp' | 'ft', v: DynamicStatDoc): number | undefined => {
+      const have = cur?.[k]; if (have === undefined) return undefined;
+      if (Math.abs(v.b - have.b) < 0.5) return undefined;
+      const nowMs = Date.now();
+      const steps = (player.baseStepAt ??= {});
+      if (v.b < 1 || v.b > MAX_BASE || Math.abs(v.b - have.b) > MAX_BASE_STEP
+        || (steps[k] !== undefined && nowMs - steps[k] < BASE_STEP_WINDOW_MS)) {
+        noteGain(ctx, player, 'base_step', { stat: k, from: have.b, to: v.b });
+        return undefined;
+      }
+      steps[k] = nowMs;
+      return v.b;
+    };
     const raise = (k: 'hp' | 'mp' | 'ft', v: DynamicStatDoc) => {
-      // `have.b`, NEVER `v.b`: `v` is the client's own untrusted body, so capping against
-      // its claimed base let a modified client assert `{c: 99999, b: 99999}` and be stored at
-      // ten times its real maximum -- then forwarded to the avatar as a restore.
-      const have = cur?.[k]; const want = have === undefined ? 0 : Math.min(v.c, have.b);
-      return have === undefined ? undefined : (want > have.c + 0.5 ? { c: want, b: have.b } : undefined);
+      // `have.b` (or a plausibly stepped new base), NEVER `v.b` outright: `v` is the client's
+      // own untrusted body, so capping against its claimed base let a modified client assert
+      // `{c: 99999, b: 99999}` and be stored at ten times its real maximum -- then forwarded
+      // to the avatar as a restore.
+      const have = cur?.[k]; if (have === undefined) return undefined;
+      const b = newBase(k, v) ?? have.b;
+      const want = Math.min(v.c, b);
+      if (want > have.c + 0.5 || b !== have.b) return { c: Math.max(want, Math.min(have.c, b)), b };
+      return undefined;
     };
     // MAGICKA IS THE CLIENT'S IN BOTH DIRECTIONS. The avatar never casts (avatar.lua maps the
     // spell stance to Nothing; the owner's client casts and forwards the hit), so nothing on
@@ -163,8 +190,9 @@ function handleStatsDynamic(ctx: StateCtx, player: Player, body: LTable): boolea
     // diff, which is rare, against free spells for every mage, which is constant.
     const spend = (v: DynamicStatDoc) => {
       const have = cur?.mp; if (have === undefined) return undefined;
-      const want = Math.max(0, Math.min(v.c, have.b));
-      return Math.abs(want - have.c) > 0.5 ? { c: want, b: have.b } : undefined;
+      const b = newBase('mp', v) ?? have.b;
+      const want = Math.max(0, Math.min(v.c, b));
+      return (Math.abs(want - have.c) > 0.5 || b !== have.b) ? { c: want, b } : undefined;
     };
     const r = { hp: hp && raise('hp', hp), mp: mp && spend(mp), ft: ft && raise('ft', ft) };
     if (!r.hp && !r.mp && !r.ft) return true; // nothing restored: consumed, not applied

--- a/server/test/avatarstats.test.ts
+++ b/server/test/avatarstats.test.ts
@@ -167,6 +167,22 @@ test('a client heal reaches the peer, and sustained fake healing is refused', as
   assert.equal((spend.value as { mp?: { c?: number } }).mp?.c, 10,
     'a magicka spend must reach the avatar, or casting is free while the peer owns the bars');
 
+  // A LEVEL-UP RAISES THE MAXIMUM. The base is client-authored (nothing on the peer levels
+  // anyone), so a plausibly stepped new base reaches the avatar with the current preserved --
+  // while the peer ruled the bars it used to be dropped with the rest of the claim, and the
+  // player who levelled mid-session fought on with the old pool.
+  peer.inbox.events.length = 0;
+  a.sendEvent('PlayerStatsDynamic', { ...bars(60), hp: { c: 60, b: 115 } });
+  const levelUp = await peer.waitEvent('AvatarRestore',
+    (v) => (v as { id?: number; hp?: { b?: number } })?.id === a.playerId && (v as { hp?: { b?: number } }).hp?.b === 115);
+  assert.equal((levelUp.value as { hp?: { c?: number } }).hp?.c, 60, 'the current bar is preserved across a raised maximum');
+  // ...within reason. A jump the game cannot produce is the modified-client shape: refused.
+  peer.inbox.events.length = 0;
+  a.sendEvent('PlayerStatsDynamic', { ...bars(60), hp: { c: 60, b: 900 } });
+  await new Promise((r) => setTimeout(r, 400));
+  assert.ok(!peer.inbox.events.some((e) => e.name === 'AvatarRestore' && (e.value as { hp?: { b?: number } })?.hp?.b === 900),
+    'a 785-point jump in maximum health was forwarded to the avatar');
+
   // Now the cheat: claim full health over and over. The budget (2x max health per 10s) runs
   // out and further claims are ignored -- the peer's bars stand.
   peer.inbox.events.length = 0;

--- a/wasm-build/lua-tests/run.lua
+++ b/wasm-build/lua-tests/run.lua
@@ -149,6 +149,15 @@ env.dyn.magicka.current = 50
 identity.tick(1.20)
 got = dynEvents(env.calls)
 check('the cost of a cast survives the refill from the avatar', got[#got].mp.c == 30, 'mp=' .. tostring(got[#got].mp.c))
+identity.notePeerBars(40, nil, nil)
+env.dyn.health.current = 40
+identity.tick(1.50)                -- settle: base said = 100
+local n1 = #dynEvents(env.calls)
+env.dyn.health.base = 110          -- level-up: the maximum rises, current does not
+identity.tick(1.80)
+got = dynEvents(env.calls)
+check('a raised maximum is claimed even with no change in current', #got == n1 + 1 and got[#got].hp and got[#got].hp.b == 110,
+  'events=' .. #got .. ' b=' .. tostring(got[#got] and got[#got].hp and got[#got].hp.b))
 
 -- ==================================================== social.lua: refusal text for the player
 -- SocialResult carries a WIRE CODE. It was rendered straight into the UI, so a refused op

--- a/wasm-build/mp-scenarios/s121-level-up.mjs
+++ b/wasm-build/mp-scenarios/s121-level-up.mjs
@@ -1,0 +1,45 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s121: A LEVEL-UP RAISES THE MAXIMUM ON THE BODY THAT FIGHTS. Levelling happens on the
+// player's own client (skills, attributes, level all travel as client diffs), and the peer's
+// avatar rules the bars. The new maximum has to reach the avatar, or the player who levelled
+// mid-session keeps the old health pool on the body that takes the hits until they relog --
+// and their own bar keeps snapping back to the old cap.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const parseBars = (s) => { const m = /^(\d+)\/(\d+)$/.exec(String(s ?? '')); return m ? { c: Number(m[1]), b: Number(m[2]) } : null; };
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const a = await ctx.launchClient('bot-a', '', BOOT);
+  await a.waitFor('String(window.omw.state.selfStats||"").indexOf("/") > 0', 300_000, 'the peer reports the bars of A (driving)');
+  const before = parseBars(await a.eval('window.omw.state.selfStats'));
+  ctx.log(`peer-reported health ${before.c}/${before.b}`);
+
+  // The level-up: the maximum rises by 15 on the client.
+  const want = before.b + 15;
+  await a.cmd(`sethpbase:${want}`);
+  const deadline = Date.now() + 20_000;
+  let bars = null;
+  while (Date.now() < deadline) {
+    bars = parseBars(await a.eval('window.omw.state.selfStats'));
+    if (bars && bars.b === want) break;
+    await ctx.sleep(400);
+  }
+  ctx.log(`after the level-up: peer-reported ${bars ? bars.c + '/' + bars.b : 'none'}`);
+  assert.ok(bars && bars.b === want, `the new maximum never reached the avatar (peer still reports base ${bars?.b}): a level-up mid-session is lost on the body that fights`);
+  assert.ok(bars.c >= Math.min(before.c, want), 'current health was not preserved across the new maximum');
+
+  // And a heal now reaches the new cap, not the old one.
+  await a.cmd(`sethp:${want}`);
+  const healBy = Date.now() + 20_000;
+  while (Date.now() < healBy) {
+    bars = parseBars(await a.eval('window.omw.state.selfStats'));
+    if (bars && bars.c >= want) break;
+    await ctx.sleep(400);
+  }
+  assert.ok(bars && bars.c >= want, `a heal to the new maximum stopped short: ${bars?.c}/${bars?.b}`);
+  ctx.log(`ok: the level-up reached the avatar and a heal fills the new pool (${bars.c}/${bars.b})`);
+}


### PR DESCRIPTION
## What this pass found
While the peer rules a player's bars, the client's claim was capped at the doc's base and the base itself thrown away. A player who levelled mid-session fought on with the **old health pool on the body that takes the hits**, and their own bar snapped back to the old cap, until they relogged.

## Fix
- `identity.lua` claims a bar whose maximum changed even when its current did not.
- `playerstate.ts` accepts a plausibly stepped base (≤ 60 points, one step per stat per 10 s, within [1, 2000]) and forwards it with the current preserved; a bigger jump or a second step in the window is refused and flagged (`state.implausible_gain base_step`).

## Proof
- **s121** (`sethpbase` hook): peer-reported 35/35 → 35/50 after the client's level-up; a heal fills to 50/50. PASS. s112 s113 s66 s22 PASS on the same engine.
- Unit: a 15-point step reaches the avatar; a 785-point jump does not. Lua runner 115/115.
- tsc clean; server suite 1070 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)