### PR TITLE
Gameplay pass: a far teleport was undone by a stale state sample (s122)

### DIFF
--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -201,9 +201,16 @@ local SNAP_DIST = 256
 local CORRECT_GAIN = 0.25 -- fraction of the divergence per state batch (~15 Hz)
 local lastSnapAt = 0
 local SNAP_COOLDOWN_S = 2.0
+-- OUR OWN TELEPORT, BY INPUT SEQUENCE. A state batch already in flight when we jumped still
+-- carries the place we left; reconciling against it dragged us straight back (16539 units,
+-- s122: teleport, back to the spawn 3 s later, forward again, every time). The batch says
+-- which input its pose accounts for, so a sample from before the jump is recognisable and
+-- ignored; the avatar's poses after it has followed us carry a newer sequence.
+local teleportSeq = nil
 
 local function onSelfState(e)
     if not e or not e.x then return end
+    if teleportSeq ~= nil and (tonumber(e.lastInputSeq) or 0) <= teleportSeq then return end
     local pos = self.position
     local dx, dy, dz = e.x - pos.x, e.y - pos.y, e.z - pos.z
     local dist = math.sqrt(dx * dx + dy * dy + dz * dz)
@@ -269,6 +276,7 @@ local function movementTick()
     local atOrigin = pos.x == 0 and pos.y == 0 and pos.z == 0
     if key and not atOrigin and (key ~= lastCellKey or jumped) then
         lastCellKey = key
+        teleportSeq = inputSeq -- every state sample up to here describes the old place
         mp.sendEvent('PlayerCellChange', { cellKey = key, x = pos.x, y = pos.y, z = pos.z })
     end
 

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -207,10 +207,30 @@ local SNAP_COOLDOWN_S = 2.0
 -- which input its pose accounts for, so a sample from before the jump is recognisable and
 -- ignored; the avatar's poses after it has followed us carry a newer sequence.
 local teleportSeq = nil
+local lastOwnPos = nil -- teleport (single-frame jump) detector; see PlayerCellChange below
 
 local function onSelfState(e)
     if not e or not e.x then return end
     if teleportSeq ~= nil and (tonumber(e.lastInputSeq) or 0) <= teleportSeq then return end
+    -- BEFORE THE DETECTOR HAS SEEN THE JUMP. A far teleport loads a new region, and the
+    -- engine stalls for seconds with the player already standing at the destination and no
+    -- onUpdate running -- so the cell change is not yet announced, the server keeps
+    -- streaming the old place, and those samples are delivered (events land before
+    -- onUpdate) the moment the stall ends. lastOwnPos is still the pre-stall spot: if we are
+    -- now far from it we have jumped, and a sample near where we were is from before the
+    -- jump. (s122: the 3-second drag back to the spawn, 3/3 alone, that the sequence gate
+    -- alone still let through.)
+    if lastOwnPos ~= nil then
+        local here = self.position
+        if (here - lastOwnPos):length2() > 512 * 512 then
+            local ox, oy, oz = e.x - lastOwnPos.x, e.y - lastOwnPos.y, e.z - lastOwnPos.z
+            if ox * ox + oy * oy + oz * oz < SNAP_DIST * SNAP_DIST then
+                teleportSeq = math.max(teleportSeq or 0, inputSeq)
+                mp.set('selfStale', string.format('%.0f,%.0f,%.0f seq=%s', e.x, e.y, e.z, tostring(e.lastInputSeq)))
+                return
+            end
+        end
+    end
     local pos = self.position
     local dx, dy, dz = e.x - pos.x, e.y - pos.y, e.z - pos.z
     local dist = math.sqrt(dx * dx + dy * dy + dz * dz)
@@ -237,8 +257,6 @@ local function onSelfState(e)
         mp.correctSelf(dx * CORRECT_GAIN, dy * CORRECT_GAIN, dz * CORRECT_GAIN)
     end
 end
-
-local lastOwnPos = nil -- teleport (single-frame jump) detector; see PlayerCellChange below
 
 local function movementTick()
     if mp.status().state ~= 'Joined' then

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -41,7 +41,10 @@ you both there), s118 (a fight INDOORS: the peer holds the room as an anchor -- 
 to run the server's own peer lifecycle, `managedPeer`; a hand-spawned peer never anchors a room), s119 (the peer is killed; the server notices,
 restarts it, re-anchors the cell and a fight resolves under the new one), s120 (two players two
 cells apart: one peer, two anchors, both fights resolve), s121 (a level-up's new maximum reaches the
-avatar and a heal fills the new pool -- FAILED first: the base was thrown away while the peer ruled), s95 (play with friends -- FAILED first: every
+avatar and a heal fills the new pool -- FAILED first: the base was thrown away while the peer ruled), s122 (a
+far teleport STICKS -- FAILED 3/3 first: a state sample from before the jump, delivered after the
+region-load stall, dragged the player back to where they left; every fast travel, Recall and door had
+this window), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/wasm-build/mp-scenarios/s122-teleport-sticks.mjs
+++ b/wasm-build/mp-scenarios/s122-teleport-sticks.mjs
@@ -1,0 +1,39 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s122: A TELEPORT STICKS. Fast travel, Recall, a Divine Intervention, a door: the player
+// lands somewhere far and must STAY there. Two competing authorities can pull them back --
+// the peer's avatar stream (until the avatar arrives) and the rejoin position hold -- and a
+// late loser drags the player to where they were, then the other side drags them back
+// again. Seen twice in batches (s110/s117: -2,-7 -> -2,-9 -> -2,-7 -> -2,-9) and never
+// alone. This snaps far, watches the cell for a while, and prints every move if it wobbles.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const FAR = '-12500,-53100,512'; // -2,-7, two cells from the Seyda Neen spawn (-2,-9)
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-7');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const a = await ctx.launchClient('bot-a', '', BOOT);
+  await a.waitFor('window.omw.state.state === "Joined"', 60_000, 'A joined');
+  await a.waitFor('String(window.omw.state.baselineReady||"") === "1"', 60_000, 'the character is settled (chargen done or restore landed)');
+  ctx.log(`restoreFired=${await a.eval('window.omw.state.restoreFired')} restorePos=${await a.eval('window.omw.state.restorePos')}`);
+  const home = String(await a.eval('window.omw.state.cell||""'));
+  await a.cmd('snapto:' + FAR);
+  await a.waitFor('String(window.omw.state.cell||"") === "-2,-7"', 30_000, 'A landed two cells north');
+
+  // Stay put for 20 s. Every cell the mirror shows is recorded; anything but -2,-7 is a drag.
+  const seen = new Set();
+  const until = Date.now() + 20_000;
+  while (Date.now() < until) {
+    seen.add(String(await a.eval('window.omw.state.cell||""')));
+    await ctx.sleep(250);
+  }
+  const wobble = [...seen].filter((c) => c !== '-2,-7');
+  if (wobble.length) {
+    const lines = (a.logTail ? a.logTail(4000) : '').split(String.fromCharCode(10)).filter((l) => /\[mp\]/.test(l) && /SNAP|snap|restore|teleport|cell|hold/.test(l)).slice(-40);
+    ctx.log('A movement-related [mp] lines: ' + lines.join(' || '));
+  }
+  assert.equal(wobble.length, 0, `A was dragged out of -2,-7 after the teleport (cells seen: ${[...seen].join(', ')}; home was ${home})`);
+  ctx.log('ok: the teleport stuck for 20 s');
+}


### PR DESCRIPTION
## What this pass found
**s122** (snap two cells away and stay) failed 3/3 alone: about 3 s after the jump the client hard-snapped 16539 units back to the spawn, then forward again. A far teleport loads a new region and the browser engine stalls for seconds with the player already at the destination and no `onUpdate` running — so the cell change is not yet announced, the server keeps streaming the old place, and those samples are delivered (events land before `onUpdate`) the moment the stall ends. Reconciliation took them as truth. **Every fast travel, Recall, Intervention and door had this window**; the batch sweeps showed it as `-2,-7 → -2,-9 → -2,-7 → -2,-9` in s110/s117.

## Fix (client, player.lua)
- `onSelfState` checks the jump inline: `lastOwnPos` is still the pre-stall spot, so a sample near where we *were* while we are now far away is from before the jump and is ignored (mirrored as `selfStale`).
- The input sequence at our own teleport is recorded; samples up to it are ignored until the avatar has followed.

## Proof
- s122 PASS 3/3 (was FAIL 3/3). s10 s109 s110 s117 s21 s22 s41 s44 s48 s51 s67 s69 s80 PASS on the same engine.
- Lua runner 116/116; server suite 1070 tests, 0 fail (no server change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)