### PR TITLE
Gameplay pass: escort quests and dialogue-sent NPC travel, live (s123, s124)

### DIFF
--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -30,6 +30,7 @@ local reportedId = nil
 -- an empty combat state, so nothing there knew a fight was on: the player could open the rest
 -- dialog mid-bite. Reported on change like the follow, and relayed the same way (ActorAI).
 local reportedCombat = nil
+local escortSaid = 0 -- peer diagnostic cadence (above)
 
 -- ...and where we are travelling, if a script sent us. On a puppet the AI never runs, so the
 -- top of the package stack is static -- the only thing that can change it is a dialogue result
@@ -86,6 +87,24 @@ return {
             if now < nextPoll then return end
             nextPoll = now + POLL
 
+            -- Diagnostic on the PEER only: an escorting/following NPC says where it is with
+            -- its charge every few seconds (s123). Silent for everything else.
+            local mpapi = require('openmw.mp')
+            if mpapi.isSystem and mpapi.isSystem() then
+                local okA, pkg = pcall(function() return I.AI.getActivePackage() end)
+                if okA and pkg and (pkg.type == 'Escort' or pkg.type == 'Follow') then
+                    escortSaid = (escortSaid or 0) + 1
+                    if escortSaid % 5 == 1 then
+                        local t = pkg.target
+                        local okd, d = pcall(function() return (t.position - self.position):length() end)
+                        local okp, dp = pcall(function() return (pkg.destPosition - self.position):length() end)
+                        print(string.format('[mp] %s on peer: %s leader=%s at %s; dest %s away; pos=(%.0f,%.0f,%.0f)',
+                            pkg.type, tostring(self.object.recordId), t and tostring(t.recordId) or 'none',
+                            okd and string.format('%.0f', d) or '?', okp and string.format('%.0f', dp) or '?',
+                            self.position.x, self.position.y, self.position.z))
+                    end
+                end
+            end
             -- Combat first: independent of following, and its own change key.
             local foe = fightingPlayer()
             local foeId = foe and foe.id or nil
@@ -110,6 +129,13 @@ return {
             reportedId = id
             -- Scenario mirror (s114): the last follow fact this actor reported.
             pcall(function() require('openmw.mp').set('companionReport', tostring(self.object.recordId) .. '=' .. tostring(id)) end)
+            -- On the peer this is the holder's own NPC changing its mind: worth a line (s123).
+            local mpapi = require('openmw.mp')
+            if mpapi.isSystem and mpapi.isSystem() then
+                local okA, pkg = pcall(function() return I.AI.getActivePackage() end)
+                print(string.format('[mp] companion report on peer: %s -> %s active=%s dest=%s', tostring(self.object.recordId), tostring(id),
+                    tostring(okA and pkg and pkg.type), tostring(okA and pkg and pkg.destPosition)))
+            end
 
             -- The GLOBAL script decides whether we are the cell's authority and whether this
             -- is worth putting on the wire. This script only knows a fact about itself.

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2793,8 +2793,16 @@ local eventHandlers = {
                     return
                 end
                 -- The builtin ai.lua handles this on the NPC's own script, exactly like a
-                -- dialogue result's AIFollow lands.
-                local ok, err = pcall(function() obj:sendEvent('StartAIPackage', { type = 'Follow', target = playerScript() }) end)
+                -- dialogue result's AIFollow / AIEscort / AITravel lands.
+                local pkg
+                if data.travel then
+                    pkg = { type = 'Travel', destPosition = util.vector3(data.travel.x, data.travel.y, data.travel.z) }
+                elseif data.escort then
+                    pkg = { type = 'Escort', target = playerScript(), destPosition = util.vector3(data.escort.x, data.escort.y, data.escort.z), duration = 0 }
+                else
+                    pkg = { type = 'Follow', target = playerScript() }
+                end
+                local ok, err = pcall(function() obj:sendEvent('StartAIPackage', pkg) end)
                 pcall(function() mp.set('testFollow', ok and ('sent:' .. tostring(obj.id)) or ('failed:' .. tostring(err))) end)
                 return
             end

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -748,6 +748,12 @@ local function dispatch(cmd)
         -- companion chain (companion.lua -> ActorAI claim -> holder) takes it from there (s114).
         local followRec = cmd:match('^follow:(.+)$')
         if followRec then core.sendGlobalEvent('mpTestFollow', { id = followRec }) end
+        -- escort:<record>:x,y,z / travel:<record>:x,y,z: the other two dialogue results
+        -- ("AIEscort player 0 x y z", "AITravel x y z") stacked on the local copy (s123, s124).
+        local escRec, ex, ey, ez = cmd:match('^escort:(.+):(-?[%d.]+),(-?[%d.]+),(-?[%d.]+)$')
+        if escRec then core.sendGlobalEvent('mpTestFollow', { id = escRec, escort = { x = tonumber(ex), y = tonumber(ey), z = tonumber(ez) } }) end
+        local trvRec, tx, ty, tz = cmd:match('^travel:(.+):(-?[%d.]+),(-?[%d.]+),(-?[%d.]+)$')
+        if trvRec then core.sendGlobalEvent('mpTestFollow', { id = trvRec, travel = { x = tonumber(tx), y = tonumber(ty), z = tonumber(tz) } }) end
         local probeRec = cmd:match('^followprobe:(.+)$')
         if probeRec then core.sendGlobalEvent('mpTestFollow', { id = probeRec, probe = true }) end
         if cmd == 'dlg:release' then

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -44,7 +44,9 @@ cells apart: one peer, two anchors, both fights resolve), s121 (a level-up's new
 avatar and a heal fills the new pool -- FAILED first: the base was thrown away while the peer ruled), s122 (a
 far teleport STICKS -- FAILED 3/3 first: a state sample from before the jump, delivered after the
 region-load stall, dragged the player back to where they left; every fast travel, Recall and door had
-this window), s95 (play with friends -- FAILED first: every
+this window), s123 (an escort quest: the NPC leads ~450 units, waits for its charge, continues;
+arrives on both screens), s124 ("AITravel" from a dialogue: the NPC walks 2900 units to where it was
+sent, on both screens), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
@@ -147,7 +149,7 @@ scenario is a code trace only.
 | Persuasion (bribe/taunt/admire) | lock holder relays disposition | FIXED 09-11 |
 | Taunt -> fight; resist arrest -> fight | lock holder claims combat; holder starts it | FIXED 09-11 |
 | Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors. companion.lua was listed on two lines (NPC, CREATURE) and the engine keeps the last: NO NPC carried it until 09-12 -- every claim below was creature-only | FIXED 09-10/11, REALLY FIXED 09-12. Live: s114 |
-| Dialogue-started AiTravel | companion.lua reports; lock holder claim (see the two-lines note above: dead on NPCs until 09-12) | FIXED 09-11/12 |
+| Dialogue-started AiTravel | companion.lua reports; lock holder claim (see the two-lines note above: dead on NPCs until 09-12) | FIXED 09-11/12. Live: s124 (travel), s123 (escort) |
 | Dialogue-started AiWander / AiActivate | not relayed; the holder's copy keeps its own package (cosmetic: an NPC told to stand still by a dialogue keeps wandering elsewhere) | OK (cosmetic) |
 | Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11 |
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |

--- a/wasm-build/mp-scenarios/s123-escort.mjs
+++ b/wasm-build/mp-scenarios/s123-escort.mjs
@@ -31,12 +31,26 @@ export default async function run(ctx) {
   await ctx.sleep(3_000);
   ctx.log(`A asked "${rec}" to escort them to the spawn (claim=${await a.eval('window.omw.state.followClaim')}, report=${await a.eval('window.omw.state.companionReport')}); ${Math.round(dist2(start, DEST))} units to go`);
 
-  // A tags along (an escort waits for its charge); B watches from the spawn.
-  const deadline = Date.now() + 120_000;
+  // A tags along: an escort walks only while its charge is within ~450 units (aiescort.cpp),
+  // and the avatar follows the client only on a JUMP of 512+ units (the pose stream is the
+  // peer's while it simulates) -- so A catches up in strides, like a player who lets the
+  // guide get ahead and then jogs after them. B watches from the spawn.
+  const deadline = Date.now() + 150_000;
   let dB = Infinity, dA = Infinity;
+  let stood = { x: start.x + 80, y: start.y };
   while (Date.now() < deadline) {
     const qa = await probeOf(a);
-    if (qa[rec]) { dA = dist2(qa[rec], DEST); await a.cmd(`snapto:${Math.round(qa[rec].x + 60)},${Math.round(qa[rec].y)},${Math.round(qa[rec].z + 8)}`); }
+    if (qa[rec]) {
+      dA = dist2(qa[rec], DEST);
+      // The guide has walked its ~450 and is waiting: stride after it. A stride is at least
+      // 512 units (the avatar follows only a jump that big) and lands just short of the guide.
+      const gap = dist2(qa[rec], stood);
+      if (gap >= 460) {
+        const step = Math.max(540, gap - 40); // the jump detector wants MORE than 512
+        stood = { x: stood.x + (qa[rec].x - stood.x) * step / gap, y: stood.y + (qa[rec].y - stood.y) * step / gap };
+        await a.cmd(`snapto:${Math.round(stood.x)},${Math.round(stood.y)},${Math.round(qa[rec].z + 8)}`);
+      }
+    }
     const qb = await probeOf(b);
     if (qb[rec]) dB = dist2(qb[rec], DEST);
     if (dB < 400 && dA < 400) break;

--- a/wasm-build/mp-scenarios/s123-escort.mjs
+++ b/wasm-build/mp-scenarios/s123-escort.mjs
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s123: AN ESCORT LEADS THE WAY, ON EVERY SCREEN. An escort quest ("AIEscort player 0 x y z"
+// from a dialogue result) is the NPC WALKING TO A DESTINATION with the player in tow -- the
+// pilgrim, the prisoner, the scared merchant. It runs on the talking player's client, whose
+// copy has its AI off, so companion.lua reports Escort with its destination, the claim
+// carries the destination, the holder starts Escort on ITS NPC, and the poses reach the
+// other player. s114 proved Follow; this is the other package the same chain carries.
+import assert from 'node:assert/strict';
+
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const dist2 = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+const DEST = { x: -12288, y: -69632, z: 87 }; // the spawn point: known dry land
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, `${c.name} puppeted the cell actors`);
+  const [pa, pb] = await Promise.all([probeOf(a), probeOf(b)]);
+  // Somebody standing well away from the destination, so the walk is measurable.
+  const rec = Object.keys(pa).find((r) => r !== 'player' && pb[r] && !pa[r].dead && !pa[r].guard
+    && !/mudcrab|scrib|rat|slaughterfish|kwama|cliff/.test(r) && dist2(pa[r], DEST) > 800);
+  assert.ok(rec, 'need a living NPC visible to both, standing away from the spawn');
+  const start = pa[rec];
+  await a.cmd(`snapto:${Math.round(start.x + 80)},${Math.round(start.y)},${Math.round(start.z + 8)}`);
+  await ctx.sleep(4_000);
+  await a.cmd(`escort:${rec}:${DEST.x},${DEST.y},${DEST.z}`);
+  await ctx.sleep(3_000);
+  ctx.log(`A asked "${rec}" to escort them to the spawn (claim=${await a.eval('window.omw.state.followClaim')}, report=${await a.eval('window.omw.state.companionReport')}); ${Math.round(dist2(start, DEST))} units to go`);
+
+  // A tags along (an escort waits for its charge); B watches from the spawn.
+  const deadline = Date.now() + 120_000;
+  let dB = Infinity, dA = Infinity;
+  while (Date.now() < deadline) {
+    const qa = await probeOf(a);
+    if (qa[rec]) { dA = dist2(qa[rec], DEST); await a.cmd(`snapto:${Math.round(qa[rec].x + 60)},${Math.round(qa[rec].y)},${Math.round(qa[rec].z + 8)}`); }
+    const qb = await probeOf(b);
+    if (qb[rec]) dB = dist2(qb[rec], DEST);
+    if (dB < 400 && dA < 400) break;
+    await ctx.sleep(2_000);
+  }
+  ctx.log(`escort distance to the destination: on A ${Math.round(dA)}, on B ${Math.round(dB)}`);
+  assert.ok(dB < 400, `B never saw "${rec}" walk to the destination (${Math.round(dB)} units away): the escort claim did not start the package on the holder`);
+  ctx.log(`ok: "${rec}" escorted A to the spawn, and B saw it walk there`);
+}

--- a/wasm-build/mp-scenarios/s124-scripted-travel.mjs
+++ b/wasm-build/mp-scenarios/s124-scripted-travel.mjs
@@ -1,0 +1,50 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s124: "I'LL MEET YOU THERE" -- A DIALOGUE SENDS AN NPC WALKING. "AITravel x y z" on
+// Goodbye is how Morrowind moves quest NPCs: the guide leaves for the shrine, the informant
+// heads for the docks. It runs on the talking player's client (AI off there), so
+// companion.lua reports the Travel package, the claim is admitted from the player who holds
+// the NPC's dialogue lock, and the holder walks its NPC. Everyone else must see the NPC go.
+import assert from 'node:assert/strict';
+
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const dist2 = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+const DEST = { x: -12288, y: -69632, z: 87 };
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, `${c.name} puppeted the cell actors`);
+  const [pa, pb] = await Promise.all([probeOf(a), probeOf(b)]);
+  const rec = Object.keys(pa).find((r) => r !== 'player' && pb[r] && !pa[r].dead && !pa[r].guard
+    && !/mudcrab|scrib|rat|slaughterfish|kwama|cliff/.test(r) && dist2(pa[r], DEST) > 800);
+  assert.ok(rec, 'need a living NPC visible to both, standing away from the spawn');
+  const start = pa[rec];
+  await a.cmd(`snapto:${Math.round(start.x + 80)},${Math.round(start.y)},${Math.round(start.z + 8)}`);
+  await ctx.sleep(3_000);
+
+  // The conversation: the lock is what admits the travel claim. The dialogue result lands
+  // while it is held; Goodbye releases it (dlg:release) -- and companion.lua only polls once
+  // the game is unpaused, so the claim goes out right after, inside the server's grace.
+  await a.cmd(`dlg:${rec}`);
+  await ctx.sleep(1_500);
+  await a.cmd(`travel:${rec}:${DEST.x},${DEST.y},${DEST.z}`);
+  await a.cmd('dlg:release');
+  await ctx.sleep(3_000);
+  ctx.log(`A sent "${rec}" walking to the spawn (${Math.round(dist2(start, DEST))} units); report=${await a.eval('window.omw.state.companionReport')}`);
+
+  const deadline = Date.now() + 120_000;
+  let dB = Infinity, dA = Infinity;
+  while (Date.now() < deadline) {
+    const [qa, qb] = await Promise.all([probeOf(a), probeOf(b)]);
+    if (qa[rec]) dA = dist2(qa[rec], DEST);
+    if (qb[rec]) dB = dist2(qb[rec], DEST);
+    if (dB < 400 && dA < 400) break;
+    await ctx.sleep(2_000);
+  }
+  ctx.log(`NPC distance to the destination: on A ${Math.round(dA)}, on B ${Math.round(dB)}`);
+  assert.ok(dB < 400 && dA < 400, `"${rec}" never arrived (A ${Math.round(dA)}, B ${Math.round(dB)}): the travel claim was refused or the holder did not start the package`);
+  ctx.log(`ok: "${rec}" walked to where the dialogue sent it, on both screens`);
+}


### PR DESCRIPTION
## Live proof for the two companion-chain branches nothing had exercised since companion.lua reached NPCs (#45)
- **s124** "AITravel x y z" on Goodbye: A holds the NPC's dialogue lock, the result stacks Travel on A's copy, the claim is admitted, the peer walks its NPC 2900 units to the spot, and B sees it arrive. PASS first run.
- **s123** an escort quest ("AIEscort player 0 x y z"): the NPC leads ~450 units, waits for its charge (aiescort.cpp), continues when the player catches up, and arrives on both screens. PASS 3× once the scenario strode after the guide like a player does (the avatar follows the client only on a 512+ jump; a 512-exactly stride was not one).
- Test hooks `escort:<record>:x,y,z` / `travel:<record>:x,y,z`; the peer prints escort/follow progress for its NPCs.

## Gates
- s114 s117 s124 s51 s61 s78 PASS on the engine baked from this branch; Lua runner 116/116; server suite 1070 tests, 0 fail (no server change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)