### PR TITLE
s125: theft is judged on the granted take and the party carries the bounty (live)

### DIFF
--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2781,6 +2781,25 @@ local eventHandlers = {
     mpTestQuest = function(data) quests.testSetQuestStage(data.id, data.stage) end,
     mpTestGlobal = function(data) quests.testSetGlobal(data.name, data.value) end,
     mpTestBounty = function(data) quests.testSetBounty(data.n) end,
+    mpTestTakeOwned = function()
+        local player = playerScript()
+        if not (player and player.cell) then return end
+        local best, bestD = nil, math.huge
+        pcall(function()
+            for _, obj in ipairs(player.cell:getAll(types.Item)) do
+                local ok, owned = pcall(function() return obj.owner and obj.owner.recordId ~= nil and types.Item.isCarriable(obj) end)
+                if ok and owned and obj.contentFile then
+                    local d = (obj.position - player.position):length()
+                    if d < bestD then best, bestD = obj, d end
+                end
+            end
+        end)
+        if not best then mp.set('takeOwned', 'none'); print('[mp] takeowned: nothing owned here'); return end
+        mp.set('takeOwned', string.format('%s of %s at %.0f', tostring(best.recordId), tostring(best.owner.recordId), bestD))
+        -- Stand beside it first: theft is judged where the hand is.
+        pcall(function() player:teleport(player.cell, best.position + util.vector3(40, 0, 8)) end)
+        pcall(function() best:activateBy(player) end)
+    end,
     mpTestFaction = function(data) quests.testJoinFaction(data.id, data.rank) end,
     mpTestDialogue = function(data) quests.testActivateNpc(data.id) end,
     -- The player pressed something (player.lua): the rejoin position hold must let go.

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -2785,16 +2785,28 @@ local eventHandlers = {
         local player = playerScript()
         if not (player and player.cell) then return end
         local best, bestD = nil, math.huge
-        pcall(function()
-            for _, obj in ipairs(player.cell:getAll(types.Item)) do
-                local ok, owned = pcall(function() return obj.owner and obj.owner.recordId ~= nil and types.Item.isCarriable(obj) end)
+        local scanned, errs = 0, nil
+        local okScan, errScan = pcall(function()
+            -- getAll() with no type: types.Item is a category, not a record type, and asking
+            -- for it returned nothing (silently, under the pcall this used to hide in).
+            for _, obj in ipairs(player.cell:getAll()) do
+                scanned = scanned + 1
+                local ok, owned = pcall(function()
+                    return types.Item.objectIsInstance(obj) and types.Item.isCarriable(obj) and obj.owner and obj.owner.recordId ~= nil
+                end)
+                if not ok then errs = owned end
                 if ok and owned and obj.contentFile then
                     local d = (obj.position - player.position):length()
                     if d < bestD then best, bestD = obj, d end
                 end
             end
         end)
-        if not best then mp.set('takeOwned', 'none'); print('[mp] takeowned: nothing owned here'); return end
+        if not okScan then errs = errScan end
+        if not best then
+            mp.set('takeOwned', 'none (scanned ' .. scanned .. (errs and (', err: ' .. tostring(errs)) or '') .. ')')
+            print('[mp] takeowned: nothing owned here (scanned ' .. scanned .. ')')
+            return
+        end
         mp.set('takeOwned', string.format('%s of %s at %.0f', tostring(best.recordId), tostring(best.owner.recordId), bestD))
         -- Stand beside it first: theft is judged where the hand is.
         pcall(function() player:teleport(player.cell, best.position + util.vector3(40, 0, 8)) end)

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -732,6 +732,9 @@ local function dispatch(cmd)
             core.sendGlobalEvent('mpSelfSnap',
                 { x = tonumber(snX), y = tonumber(snY), z = tonumber(snZ) })
         end
+        -- takeowned: pick up the nearest item in this cell that BELONGS to someone -- a theft,
+        -- through the same activation the hand uses, with the owner in the room (s125).
+        if cmd == 'takeowned' then core.sendGlobalEvent('mpTestTakeOwned', {}) end
         local bountyN = cmd:match('^bounty:(%d+)$')
         if bountyN then core.sendGlobalEvent('mpTestBounty', { n = tonumber(bountyN) }) end
         local facId, facRank = cmd:match('^faction:([^:]+):(%d+)$')

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -46,7 +46,8 @@ far teleport STICKS -- FAILED 3/3 first: a state sample from before the jump, de
 region-load stall, dragged the player back to where they left; every fast travel, Recall and door had
 this window), s123 (an escort quest: the NPC leads ~450 units, waits for its charge, continues;
 arrives on both screens), s124 ("AITravel" from a dialogue: the NPC walks 2900 units to where it was
-sent, on both screens), s95 (play with friends -- FAILED first: every
+sent, on both screens), s125 (theft: an owned bottle taken in the shop with the owner there;
+the granted take runs the engine's ActionTake, the bounty rises, and the party shares it), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),

--- a/wasm-build/mp-scenarios/s125-theft.mjs
+++ b/wasm-build/mp-scenarios/s125-theft.mjs
@@ -32,7 +32,7 @@ export default async function run(ctx) {
   await a.waitFor('String(window.omw.state.takeOwned||"") !== ""', STEP, 'A picked something to steal');
   const what = await a.eval('window.omw.state.takeOwned');
   ctx.log(`A steals: ${what}`);
-  assert.notEqual(what, 'none', 'nothing owned in this shop');
+  assert.ok(!String(what).startsWith('none'), `nothing owned in this shop: ${what}`);
 
   await a.waitFor('Number(window.omw.state.bounty||"0") > 0', 60_000, 'A is wanted (the theft was judged on the granted take)');
   const ba = await bountyOf(a);

--- a/wasm-build/mp-scenarios/s125-theft.mjs
+++ b/wasm-build/mp-scenarios/s125-theft.mjs
@@ -1,0 +1,41 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s125: STEALING HAS CONSEQUENCES, FOR THE WHOLE PARTY. A picks up something that belongs to
+// the shopkeeper, in the shop, with the shopkeeper standing there. The take is a server
+// request (s79), the granted take runs the engine's own ActionTake -- which is where theft
+// is judged and the bounty raised -- the CrimeUpdate travels, and with [sharing] crime = true
+// the party carries one record: B, who took nothing, is wanted too. Without the real
+// ActionTake on the granted path, theft in a shared world would be free.
+import assert from 'node:assert/strict';
+
+export const managedPeer = true;
+const STEP = 30_000;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const cellOf = async (c) => String(await c.eval('window.omw.state.cell||""'));
+const bountyOf = async (c) => Number(await c.eval('window.omw.state.bounty||"0"') || 0);
+
+export default async function run(ctx) {
+  const simPeer = ctx.startSimPeer('-2,-9');
+  if (!simPeer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset).'); return; }
+  const [a, b] = await Promise.all([ctx.launchClient('bot-a', '', BOOT), ctx.launchClient('bot-b', '', BOOT)]);
+  for (const c of [a, b]) await c.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, `${c.name} puppeted the cell actors`);
+  const outside = await cellOf(a);
+  for (const c of [a, b]) {
+    await c.cmd('door:enter');
+    await c.waitFor(`String(window.omw.state.cell||"") !== ${JSON.stringify(outside)}`, STEP, `${c.name} went inside`);
+  }
+  ctx.log(`both inside "${await cellOf(a)}"; bounties A=${await bountyOf(a)} B=${await bountyOf(b)}`);
+  assert.equal(await bountyOf(a), 0, 'A starts clean');
+  await ctx.sleep(3_000);
+
+  await a.cmd('takeowned');
+  await a.waitFor('String(window.omw.state.takeOwned||"") !== ""', STEP, 'A picked something to steal');
+  const what = await a.eval('window.omw.state.takeOwned');
+  ctx.log(`A steals: ${what}`);
+  assert.notEqual(what, 'none', 'nothing owned in this shop');
+
+  await a.waitFor('Number(window.omw.state.bounty||"0") > 0', 60_000, 'A is wanted (the theft was judged on the granted take)');
+  const ba = await bountyOf(a);
+  await b.waitFor('Number(window.omw.state.bounty||"0") > 0', STEP, 'B is wanted too (crime is shared with the party)');
+  ctx.log(`ok: theft judged -- bounty A=${ba} B=${await bountyOf(b)}`);
+}


### PR DESCRIPTION
## Live proof
**s125**: A picks up a bottle that belongs to the shopkeeper, in the shop, with the owner there. The take is a server request; the granted take runs the engine's own ActionTake, where theft is judged; the CrimeUpdate travels; with `[sharing] crime = true` B, who took nothing, is wanted too (bounty 1 on both). PASS.

Test hook `takeowned` (nearest owned carriable in the cell, through the same activation the hand uses). No product changes; Lua runner 116/116; server suite 1070 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)