### PR TITLE
s126: the guard catches you, the arrest dialogue opens on the wanted player's client (live)

### DIFF
--- a/openmw/files/data/scripts/mp/companion.lua
+++ b/openmw/files/data/scripts/mp/companion.lua
@@ -92,7 +92,7 @@ return {
             local mpapi = require('openmw.mp')
             if mpapi.isSystem and mpapi.isSystem() then
                 local okA, pkg = pcall(function() return I.AI.getActivePackage() end)
-                if okA and pkg and (pkg.type == 'Escort' or pkg.type == 'Follow') then
+                if okA and pkg and (pkg.type == 'Escort' or pkg.type == 'Follow' or pkg.type == 'Pursue') then
                     escortSaid = (escortSaid or 0) + 1
                     if escortSaid % 5 == 1 then
                         local t = pkg.target

--- a/openmw/files/data/scripts/mp/global.lua
+++ b/openmw/files/data/scripts/mp/global.lua
@@ -876,6 +876,7 @@ local function avatarArrestTick()
                 for _, guard in ipairs(guards) do
                     local okv, valid = pcall(function() return guard:isValid() end)
                     if okv and valid then
+                        print(string.format('[mp] arrest: %s reached avatar #%s', tostring(guard.recordId), tostring(id)))
                         mp.sendEvent('PlayerArrest', { id = id, guard = guard })
                     end
                 end

--- a/openmw/files/data/scripts/mp/player.lua
+++ b/openmw/files/data/scripts/mp/player.lua
@@ -258,6 +258,17 @@ local function onSelfState(e)
     end
 end
 
+-- The UI mode, mirrored ON CHANGE (it used to be written only on a key press, so a dialogue
+-- the engine opened by itself -- an arrest, s126 -- was invisible to the scenarios).
+local lastUiModeSaid = nil
+local function uiModeMirrorTick()
+    local ok, mode = pcall(function() return tostring(I.UI.getMode() or 'none') end)
+    if ok and mode ~= lastUiModeSaid then
+        lastUiModeSaid = mode
+        mp.set('uiMode', mode)
+    end
+end
+
 local function movementTick()
     if mp.status().state ~= 'Joined' then
         lastCellKey = nil -- rejoin resends PlayerCellChange (required to become visible)
@@ -268,6 +279,7 @@ local function movementTick()
     inputTick(now) -- Phase 3: raw intent to the peer, beside the pose stream
     identity.tick(now) -- M2: appearance/equipment/stats/inventory diff broadcasts
     identity.equipRetryTick(now)
+    uiModeMirrorTick()
 
     -- PlayerCellChange: immediately once Joined (before it we are invisible and receive no
     -- batches), then on every cell change -- AND on any single-frame position jump. A jump

--- a/server/docs/MP-COVERAGE-MAP.md
+++ b/server/docs/MP-COVERAGE-MAP.md
@@ -47,7 +47,8 @@ region-load stall, dragged the player back to where they left; every fast travel
 this window), s123 (an escort quest: the NPC leads ~450 units, waits for its charge, continues;
 arrives on both screens), s124 ("AITravel" from a dialogue: the NPC walks 2900 units to where it was
 sent, on both screens), s125 (theft: an owned bottle taken in the shop with the owner there;
-the granted take runs the engine's ActionTake, the bounty rises, and the party shares it), s95 (play with friends -- FAILED first: every
+the granted take runs the engine's ActionTake, the bounty rises, and the party shares it), s126 (the guard catches you: the peer's guard
+reaches the avatar, PlayerArrest travels, the arrest dialogue opens on the wanted player's client), s95 (play with friends -- FAILED first: every
 join refused not_open, fixed the same day), s100 (invite across worlds), s102 (owner goes
 solo), s61 (dialogue lock), s72 (merchant purse), s03 (chat), s10 (movement puppets), s20
 (identity), s21 (rejoin), s80 (resume), s81 (reconnect), s70 (time), s48/s56 (world switch),
@@ -152,7 +153,7 @@ scenario is a code trace only.
 | Follow / Escort (recruit, escort quests) | companion.lua -> ActorAI claim -> holder; replayed to a new peer; carried through doors. companion.lua was listed on two lines (NPC, CREATURE) and the engine keeps the last: NO NPC carried it until 09-12 -- every claim below was creature-only | FIXED 09-10/11, REALLY FIXED 09-12. Live: s114 |
 | Dialogue-started AiTravel | companion.lua reports; lock holder claim (see the two-lines note above: dead on NPCs until 09-12) | FIXED 09-11/12. Live: s124 (travel), s123 (escort) |
 | Dialogue-started AiWander / AiActivate | not relayed; the holder's copy keeps its own package (cosmetic: an NPC told to stand still by a dialogue keeps wandering elsewhere) | OK (cosmetic) |
-| Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11 |
+| Guards: crime pursuit, arrest dialogue | registry bounty; AiPursue reaches; PlayerArrest to owner | FIXED 09-11. Live: s78 (pursuit), s126 (arrest dialogue opens) |
 | Assault / murder as crimes | commitCrime/actorKilled accept avatars; PlayerCrime to owner | FIXED 09-11 |
 | Death, loot, corpse | ActorDeath, corpse container canonical | OK |
 | Content-placed NPCs/creatures | content RefNum, addressable everywhere | OK |

--- a/wasm-build/mp-scenarios/s126-arrest.mjs
+++ b/wasm-build/mp-scenarios/s126-arrest.mjs
@@ -1,0 +1,42 @@
+// Copyright (C) 2025-2026 Virtastic - https://virtastic.app
+// SPDX-License-Identifier: GPL-3.0-or-later | part of openmw-web
+// s126: THE GUARD CATCHES YOU. s78 proves a guard the peer simulates pursues a wanted avatar.
+// This is what happens when it gets there: on the peer a guard reaching an avatar cannot open
+// a dialogue nobody is there to see, so the engine records the reach (mwmp/puppets.hpp
+// recordArrest), the peer hands it to the server (PlayerArrest), and the owner's client opens
+// the dialogue with ITS copy of that guard -- vanilla's own greeting does the rest (pay the
+// fine, go to jail, resist). The wanted player stands still so the guard can reach them.
+import assert from 'node:assert/strict';
+
+export const serverRules = `
+[content]
+enforce = "off"
+`;
+const BOOT = { retail: true, joinTimeoutMs: 420_000 };
+const STEP = 30_000;
+const BOUNTY = 6_000;
+const probeOf = async (c) => JSON.parse(await c.eval('window.omw.state.actorProbe||"{}"'));
+const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+
+export default async function run(ctx) {
+  const peer = ctx.startSimPeer('-2,-9');
+  if (!peer) { ctx.log('SKIP: no simulating sim peer available (OMW_SIM_PEER_BIN unset)'); return; }
+  const a = await ctx.launchClient('crook', '', BOOT);
+  await a.waitFor('Number(window.omw.state.puppetedActors||0) > 0', 300_000, 'the peer holds the cell');
+  const me = JSON.parse(await a.eval('window.omw.state.pose||"null"'));
+  const probe = await probeOf(a);
+  const guards = Object.keys(probe).filter((r) => probe[r].guard && !probe[r].dead)
+    .sort((x, y) => dist(me, probe[x]) - dist(me, probe[y]));
+  assert.ok(guards.length, 'no living guard in this cell');
+  const g = probe[guards[0]];
+  // Stand in the guard's face: the arrest needs the guard to REACH us, and pathing across the
+  // village is s78's business, not this scenario's.
+  await a.cmd(`snapto:${Math.round(g.x + 120)},${Math.round(g.y)},${Math.round(g.z + 8)}`);
+  await ctx.sleep(4_000);
+  ctx.log(`standing beside ${guards[0]}; uiMode=${await a.eval('window.omw.state.uiMode')}`);
+  await a.cmd(`bounty:${BOUNTY}`);
+
+  await a.waitFor('String(window.omw.state.uiMode||"") === "Dialogue"', 180_000,
+    'the arrest dialogue opened on the wanted player\'s client (PlayerArrest -> MP_OpenDialogue)');
+  ctx.log(`ok: ${guards[0]} caught the player and the arrest dialogue opened (bounty ${await a.eval('window.omw.state.bounty')})`);
+}


### PR DESCRIPTION
## Live proof
**s126**: the wanted player stands beside a guard; the peer's guard reaches the avatar (aipursue.cpp recordArrest), the peer hands it up as PlayerArrest, the server routes it to the owner, and the arrest dialogue opens on the owner's client with its copy of the guard. PASS.

Also: `uiMode` is mirrored on change (it was written only on a key press, so a dialogue the engine opened by itself was invisible to scenarios); the peer prints arrests and pursuit progress. No product changes.

Gates: s78 s61 s03 s123 PASS on the engine baked from this branch; Lua runner 116/116; server suite 1070 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)